### PR TITLE
GCE Deployer can be configured with an arbitrary number of nodes

### DIFF
--- a/kubetest2-gce/deployer/common.go
+++ b/kubetest2-gce/deployer/common.go
@@ -117,5 +117,28 @@ func (d *deployer) buildEnv() []string {
 	// kube-up and kube-down get this as a default ("kubernetes") but log-dump
 	// does not. opted to set it manually here for maximum consistency
 	env = append(env, "KUBE_GCE_INSTANCE_PREFIX=kubetest2")
+
+	// Pass through number of nodes and associated IP range. In the future,
+	// IP range will be configurable.
+	env = append(env, fmt.Sprintf("NUM_NODES=%d", d.NumNodes))
+	env = append(env, fmt.Sprintf("CLUSTER_IP_RANGE=%s", getClusterIPRange(d.NumNodes)))
+
 	return env
+}
+
+// Taken from the kubetest bash (gce) deployer
+// Calculates the cluster IP range based on the no. of nodes in the cluster.
+// Note: This mimics the function get-cluster-ip-range used by kube-up script.
+func getClusterIPRange(numNodes int) string {
+	suggestedRange := "10.64.0.0/14"
+	if numNodes > 1000 {
+		suggestedRange = "10.64.0.0/13"
+	}
+	if numNodes > 2000 {
+		suggestedRange = "10.64.0.0/12"
+	}
+	if numNodes > 4000 {
+		suggestedRange = "10.64.0.0/11"
+	}
+	return suggestedRange
 }

--- a/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2-gce/deployer/deployer.go
@@ -63,6 +63,7 @@ type deployer struct {
 	OverwriteLogsDir            bool   `desc:"If set, will overwrite an existing logs directory if one is encountered during dumping of logs. Useful when runnning tests locally."`
 	BoskosLocation              string `desc:"If set, manually specifies the location of the boskos server. If unset and boskos is needed, defaults to http://boskos.test-pods.svc.cluster.local."`
 	LegacyMode                  bool   `desc:"Set if the provided repo root is the kubernetes/kubernetes repo and not kubernetes/cloud-provider-gcp."`
+	NumNodes                    int    `desc:"The number of nodes in the cluster."`
 }
 
 // New implements deployer.New for gce
@@ -74,6 +75,7 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 		boskosHeartbeatClose:        make(chan struct{}),
 		BoskosAcquireTimeoutSeconds: 5 * 60,
 		BoskosLocation:              "http://boskos.test-pods.svc.cluster.local.",
+		NumNodes:                    3,
 	}
 
 	flagSet, err := gpflag.Parse(d)

--- a/kubetest2-gce/deployer/up.go
+++ b/kubetest2-gce/deployer/up.go
@@ -92,6 +92,10 @@ func enableComputeAPI(project string) error {
 }
 
 func (d *deployer) verifyUpFlags() error {
+	if d.NumNodes < 1 {
+		return fmt.Errorf("number of nodes must be at least 1")
+	}
+
 	if err := d.setRepoPathIfNotSet(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Includes the suggested IP range function from the original kubetest.

Original PR: https://github.com/kubernetes/test-infra/pull/18145