### PR TITLE
Basic build, up, down CI test script to be run in prow

### DIFF
--- a/kubetest2-gce/ci-tests/buildupdown.sh
+++ b/kubetest2-gce/ci-tests/buildupdown.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "${REPO_ROOT}" || exit 1
+
+make install
+make install-deployer-gce
+
+# currently equivalent to /home/prow/go/src/github.com/kubernetes/cloud-provider-gcp
+K_REPO_ROOT="${REPO_ROOT}/../../kubernetes/cloud-provider-gcp"
+
+kubetest2 gce \
+            -v 2 \
+            --repo-root $K_REPO_ROOT \
+            --build \
+            --up \
+            --down

--- a/kubetest2-gce/deployer/common.go
+++ b/kubetest2-gce/deployer/common.go
@@ -95,10 +95,21 @@ func (d *deployer) buildEnv() []string {
 	// can be removed if env is inherited from the os
 	env = append(env, fmt.Sprintf("PATH=%s", os.Getenv("PATH")))
 
-	// used by config-test.sh to set $NETWORK in the default case
-	// if unset, bash's set -u gets angry and kills the log dump script
-	// can be removed if env is inherited from the os
-	env = append(env, fmt.Sprintf("USER=%s", os.Getenv("USER")))
+	// USER is used by config-test.sh to set $NETWORK in the default case.
+	// Also, if unset, bash's set -u gets angry and kills the log dump script.
+	//
+	// Because the log dump script uses `gcloud compute ssh` and
+	// `gcloud compute scp`, we have to check if the active user is root.
+	// This is because `gcloud compute ssh/scp` try to log in as USER@vm
+	// which is by default disabled on GCE VMs if USER is root. In order
+	// for the deployer to work without fuss when run as root (like it
+	// does by default in Prow) we can simply change USER to be something
+	// non-root.
+	if user := os.Getenv("USER"); user == "root" {
+		env = append(env, fmt.Sprintf("USER=%s", "kubetest2"))
+	} else {
+		env = append(env, fmt.Sprintf("USER=%s", user))
+	}
 
 	// kube-up.sh, kube-down.sh etc. use PROJECT as a parameter
 	// for gcloud commands

--- a/kubetest2-gce/deployer/common.go
+++ b/kubetest2-gce/deployer/common.go
@@ -104,11 +104,12 @@ func (d *deployer) buildEnv() []string {
 	// which is by default disabled on GCE VMs if USER is root. In order
 	// for the deployer to work without fuss when run as root (like it
 	// does by default in Prow) we can simply change USER to be something
-	// non-root.
-	if user := os.Getenv("USER"); user == "root" {
+	// non-root. USER is not always set in a given environment, so the UID
+	// is checked instead for guaranteed correct information.
+	if uid := os.Getuid(); uid == 0 {
 		env = append(env, fmt.Sprintf("USER=%s", "kubetest2"))
 	} else {
-		env = append(env, fmt.Sprintf("USER=%s", user))
+		env = append(env, fmt.Sprintf("USER=%s", os.Getenv("USER")))
 	}
 
 	// kube-up.sh, kube-down.sh etc. use PROJECT as a parameter

--- a/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2-gce/deployer/deployer.go
@@ -60,6 +60,7 @@ type deployer struct {
 	RepoRoot                    string `desc:"The path to the root of the local kubernetes/cloud-provider-gcp repo. Necessary to call certain scripts. Defaults to the current directory. If operating in legacy mode, this should be set to the local kubernetes/kubernetes repo."`
 	GCPProject                  string `desc:"GCP Project to create VMs in. If unset, the deployer will attempt to get a project from boskos."`
 	GCPZone                     string `desc:"GCP Zone to create VMs in. If unset, kube-up.sh and kube-down.sh defaults apply."`
+	EnableComputeAPI            bool   `desc:"If set, the deployer will enable the compute API for the project during the Up phase. This is necessary if the project has not been used before. WARNING: The currently configured GCP account must have permission to enable this API on the configured project."`
 	OverwriteLogsDir            bool   `desc:"If set, will overwrite an existing logs directory if one is encountered during dumping of logs. Useful when runnning tests locally."`
 	BoskosLocation              string `desc:"If set, manually specifies the location of the boskos server. If unset and boskos is needed, defaults to http://boskos.test-pods.svc.cluster.local."`
 	LegacyMode                  bool   `desc:"Set if the provided repo root is the kubernetes/kubernetes repo and not kubernetes/cloud-provider-gcp."`

--- a/kubetest2-gce/deployer/up.go
+++ b/kubetest2-gce/deployer/up.go
@@ -32,9 +32,11 @@ func (d *deployer) Up() error {
 		return fmt.Errorf("up failed to init: %s", err)
 	}
 
-	klog.V(2).Info("enabling compute API for project")
-	if err := enableComputeAPI(d.GCPProject); err != nil {
-		return fmt.Errorf("up couldn't enable compute API: %s", err)
+	if d.EnableComputeAPI {
+		klog.V(2).Info("enabling compute API for project")
+		if err := enableComputeAPI(d.GCPProject); err != nil {
+			return fmt.Errorf("up couldn't enable compute API: %s", err)
+		}
 	}
 
 	defer func() {


### PR DESCRIPTION
Called by this CI test: https://github.com/kubernetes/test-infra/pull/18144 (https://github.com/kubernetes/test-infra/pull/18358)

Once those are merged, this PR can be tested using the CI bot's commands.

Enabling compute API is now behind a flag because the service account the CI container has does not have permission to enable it and it is already enabled in all CI projects (as far as I can tell).

The `USER` environment variable is now set specially when the deployer is run as root. See the associated comment in the PR for details. See https://github.com/kubernetes/test-infra/pull/18413 for the associated change to the CI job description. Tested in a local environment when running as root.