### PR TITLE
Absolute path for default artifacts directory and enforce in Ginkgo tester

### DIFF
--- a/pkg/app/cmd.go
+++ b/pkg/app/cmd.go
@@ -220,7 +220,7 @@ func (o *options) bindFlags(flags *pflag.FlagSet) {
 	if err != nil {
 		panic(err)
 	}
-	flags.StringVar(&o.artifacts, "artifacts", defaultArtifacts, `directory to put artifacts, defaulting to "${ARTIFACTS:-./_artifacts}"`)
+	flags.StringVar(&o.artifacts, "artifacts", defaultArtifacts, `directory to put artifacts, defaulting to "${ARTIFACTS:-./_artifacts}". If using the ginkgo tester, this must be an absolute path.`)
 }
 
 // assert that options implements deployer options

--- a/pkg/app/testers/standard/ginkgo/ginkgo.go
+++ b/pkg/app/testers/standard/ginkgo/ginkgo.go
@@ -70,6 +70,10 @@ func NewTester(common types.Options, testArgs []string, deployer types.Deployer)
 	flags := bindFlags(&t)
 	_ = flags.Parse(testArgs)
 
+	if !filepath.IsAbs(common.ArtifactsDir()) {
+		return nil, fmt.Errorf("the ginkgo tester requires the artifacts directory to be an absolute path, it was actually: %s", common.ArtifactsDir())
+	}
+
 	t.conformanceTest = true //TODO(RonWeber): Better logic here.
 
 	return &t, nil


### PR DESCRIPTION
This PR makes the default path for the artifacts directory absolute and enforces this for all user-set (non-default) artifacts directories only in the ginkgo tester.

Making this path absolute saves several headaches when calling parts of the ginkgo tester. Specifically, if ginkgo does not have an absolute path for the kubeconfig it will fail because (most likely) it changes the working directory for some reason. By modifying the artifacts directory where it is set initially, all appends to it (like the GCE deployer does for its kubeconfig path) are safe. 

Changing paths to absolute at the deployer level could cause headaches if a user-specified artifacts directory is an absolute path.

I'm not sure if panicking is the correct behavior when the working directory cannot be found, but its the only reasonable behavior I can think of.