### PR TITLE
Default artifacts is absolute path and Ginkgo tester expands KUBECONFIG to absolute path

### DIFF
--- a/pkg/testers/ginkgo/ginkgo.go
+++ b/pkg/testers/ginkgo/ginkgo.go
@@ -70,6 +70,20 @@ func (t *Tester) Test() error {
 
 func (t *Tester) pretestSetup() error {
 	if config := os.Getenv("KUBECONFIG"); config != "" {
+		// The ginkgo tester errors out if the kubeconfig provided
+		// is not an absolute path, likely because ginkgo changes its
+		// working directory while executing. To get around this problem
+		// we can manually edit the provided KUBECONFIG to ensure a
+		// successful run.
+		if !filepath.IsAbs(config) {
+			newKubeconfig, err := filepath.Abs(config)
+			if err != nil {
+				return fmt.Errorf("failed to convert kubeconfig to absolute path: %s", err)
+			}
+			log.Printf("Ginkgo tester received a non-absolute path for KUBECONFIG. Updating to: %s", newKubeconfig)
+			config = newKubeconfig
+		}
+
 		t.kubeconfigPath = config
 	} else {
 		home, err := os.UserHomeDir()


### PR DESCRIPTION
Odd behavior was encountered when running the ginkgo tester with non-absolute paths for ARTIFACTS after running the GCE deployer. Observed behavior shows that when the ginkgo executable is called with a non-absolute path for KUBECONFIG it errors. Because the GCE deployer merely adds paths on top of ARTIFACTS, it was returning a KUBECONFIG (sent to the tester) of ARTIFACTS/kubetest2-kubeconfig which was a relative path because ARTIFACTS is, by default, "_artifacts".

This PR addresses the problem at 2 levels: it changes the default artifacts dir to have an absolute path and then ensures an absolute path for the kubeconfig passed to the ginkgo executable. While this problem could be addressed by only ensuring the kubeconfig path is absolute in the ginkgo tester, it is also better to have a good default for artifacts in case of future problems.

This is a post #9 version of #8. 