### PR TITLE
kubetest2 gke retries creating the cluster if it fails due to specific reasons

### DIFF
--- a/kubetest2-gke/deployer/commandutils.go
+++ b/kubetest2-gke/deployer/commandutils.go
@@ -45,7 +45,6 @@ func (d *deployer) prepareGcpIfNeeded() error {
 		return fmt.Errorf("--environment must be one of {test,staging,staging2,prod} or match %v, found %q", urlRe, env)
 	}
 
-	//TODO(RonWeber): boskos
 	if err := os.Setenv("CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS", "1"); err != nil {
 		return fmt.Errorf("could not set CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS=1: %v", err)
 	}
@@ -62,15 +61,17 @@ func (d *deployer) prepareGcpIfNeeded() error {
 		return err
 	}
 
-	// Ensure ssh keys exist
-	log.Print("Checking existing of GCP ssh keys...")
-	k := filepath.Join(home(".ssh"), "google_compute_engine")
-	if _, err := os.Stat(k); err != nil {
-		return err
-	}
-	pk := k + ".pub"
-	if _, err := os.Stat(pk); err != nil {
-		return err
+	if d.gcpSSHKeyRequired {
+		// Ensure ssh keys exist
+		log.Print("Checking existing of GCP ssh keys...")
+		k := filepath.Join(home(".ssh"), "google_compute_engine")
+		if _, err := os.Stat(k); err != nil {
+			return err
+		}
+		pk := k + ".pub"
+		if _, err := os.Stat(pk); err != nil {
+			return err
+		}
 	}
 
 	//TODO(RonWeber): kubemark


### PR DESCRIPTION
1. As we synced offline, `kubetest2 gke` supports retrying cluster creation if it fails due to some reasons that cannot be prevented in advance, e.g. quota running out. This is achieved by adding an extra `back-regions` flag which will enable the retry logic if it's not empty. IMO this approach is better than supporting `region` to be set as `auto` since it allows users to restrict which region(s) they want the cluster to be in, and it's also backward compatible.

2. Add a new flag `require-gcp-ssh-key` to allow the GCP SSH key to be empty, with which we can get rid of the hack in Knative - https://github.com/knative/test-infra/blob/master/scripts/e2e-tests.sh#L229-L233 (we are still using `kubetest` in Knative but will be likely switching to `kubetest2` soon).

/cc @amwat 