### PR TITLE
[Proposal] Multi project multi cluster proposal for GKE deployer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 # kubetest2 default artifacts
 _artifacts/
 bin/
+
+# VisualStudio Code specific files
+.vscode/

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	k8s.io/klog v1.0.0
 	sigs.k8s.io/boskos v0.0.0-20200710214748-f5935686c7fc
 )

--- a/kubetest2-gke/deployer/deployer.go
+++ b/kubetest2-gke/deployer/deployer.go
@@ -18,10 +18,10 @@ limitations under the License.
 package deployer
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	realexec "os/exec" // Only for ExitError; Use kubetest2/pkg/exec to actually exec stuff
 	"path/filepath"
@@ -32,8 +32,10 @@ import (
 	"sync"
 
 	"github.com/spf13/pflag"
+	"golang.org/x/sync/errgroup"
 	"k8s.io/klog"
 	"sigs.k8s.io/boskos/client"
+
 	"sigs.k8s.io/kubetest2/pkg/build"
 	"sigs.k8s.io/kubetest2/pkg/exec"
 	"sigs.k8s.io/kubetest2/pkg/metadata"
@@ -82,20 +84,24 @@ type deployer struct {
 	// doInit helps to make sure the initialization is performed only once
 	doInit sync.Once
 	// gke specific details
-	project           string
-	zone              string
-	region            string
-	cluster           string
-	nodes             int
-	machineType       string
-	network           string
-	environment       string
-	createCommandFlag string
-	gcpServiceAccount string
+	projects []string
+	zone     string
+	region   string
+	clusters []string
+	// only used for multi-project multi-cluster profile to save the project-clusters mapping
+	projectClustersLayout map[string][]string
+	nodes                 int
+	machineType           string
+	network               string
+	subnetworkRanges      []string
+	environment           string
+	createCommandFlag     string
+	gcpServiceAccount     string
 
-	kubecfgPath    string
-	testPrepared   bool
-	instanceGroups []*ig
+	kubecfgPath  string
+	testPrepared bool
+	// project -> cluster -> instance groups
+	instanceGroups map[string]map[string][]*ig
 
 	stageLocation string
 
@@ -104,6 +110,8 @@ type deployer struct {
 
 	boskosLocation              string
 	boskosAcquireTimeoutSeconds int
+	// number of boskos projects to request if `projects` is empty
+	boskosProjectsRequested int
 
 	// boskos struct field will be non-nil when the deployer is
 	// using boskos to acquire a GCP project
@@ -133,7 +141,10 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 
 // verifyCommonFlags validates flags for up phase.
 func (d *deployer) verifyUpFlags() error {
-	if d.cluster == "" {
+	if err := d.verifyNetworkFlags(); err != nil {
+		return err
+	}
+	if d.clusters == nil {
 		return fmt.Errorf("--cluster-name must be set for GKE deployment")
 	}
 	if _, err := d.location(); err != nil {
@@ -147,10 +158,10 @@ func (d *deployer) verifyUpFlags() error {
 
 // verifyDownFlags validates flags for down phase.
 func (d *deployer) verifyDownFlags() error {
-	if d.cluster == "" {
+	if d.clusters == nil {
 		return fmt.Errorf("--cluster-name must be set for GKE deployment")
 	}
-	if d.project == "" {
+	if d.projects == nil {
 		return fmt.Errorf("--project must be set for GKE deployment")
 	}
 	if _, err := d.location(); err != nil {
@@ -182,12 +193,16 @@ var _ types.NewDeployer = New
 func bindFlags(d *deployer) *pflag.FlagSet {
 	flags := pflag.NewFlagSet(Name, pflag.ContinueOnError)
 
-	flags.StringVar(&d.cluster, "cluster-name", "", "Cluster name. Must be set.")
+	flags.StringSliceVar(&d.clusters, "cluster-name", []string{}, "Cluster names separated by comma. Must be set. "+
+		"For multi-project profile, it should be in the format of clusterA:0,clusterB:1,clusterC:2, where the index means the index of the project.")
 	flags.StringVar(&d.createCommandFlag, "create-command", defaultCreate, "gcloud subcommand used to create a cluster. Modify if you need to pass arbitrary arguments to create.")
 	flags.StringVar(&d.gcpServiceAccount, "gcp-service-account", "", "Service account to activate before using gcloud")
-	flags.StringVar(&d.network, "network", "default", "Cluster network. Defaults to the default network.")
-	flags.StringVar(&d.environment, "environment", "staging", "Container API endpoint to use, one of 'test', 'staging', 'prod', or a custom https:// URL")
-	flags.StringVar(&d.project, "project", "", "Project to deploy to.")
+	flags.StringVar(&d.network, "network", "default", "Cluster network. Defaults to the default network if not provided. For multi-project use cases, this will be the Shared VPC network name.")
+	flags.StringSliceVar(&d.subnetworkRanges, "subnetwork-ranges", []string{}, "Subnetwork ranges as required for shared VPC setup as described in https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc#creating_a_network_and_two_subnets."+
+		"For multi-project profile, it is required and should be in the format of `10.0.4.0/22 10.0.32.0/20 10.4.0.0/14,172.16.4.0/22 172.16.16.0/20 172.16.4.0/22`, where the subnetworks configuration for different project"+
+		"are separated by comma, and the ranges of each subnetwork configuration is separated by space.")
+	flags.StringVar(&d.environment, "environment", "prod", "Container API endpoint to use, one of 'test', 'staging', 'prod', or a custom https:// URL. Defaults to prod if not provided")
+	flags.StringSliceVar(&d.projects, "project", []string{}, "Project to deploy to separated by comma.")
 	flags.StringVar(&d.region, "region", "", "For use with gcloud commands to specify the cluster region.")
 	flags.StringVar(&d.zone, "zone", "", "For use with gcloud commands to specify the cluster zone.")
 	flags.IntVar(&d.nodes, "num-nodes", defaultNodePool.Nodes, "For use with gcloud commands to specify the number of nodes for the cluster.")
@@ -195,6 +210,8 @@ func bindFlags(d *deployer) *pflag.FlagSet {
 	flags.StringVar(&d.stageLocation, "stage", "", "Upload binaries to gs://bucket/ci/job-suffix if set")
 	flags.StringVar(&d.boskosLocation, "boskos-location", "http://boskos.test-pods.svc.cluster.local.", "If set, manually specifies the location of the boskos server")
 	flags.IntVar(&d.boskosAcquireTimeoutSeconds, "boskos-acquire-timeout-seconds", 300, "How long (in seconds) to hang on a request to Boskos to acquire a resource before erroring")
+	flags.IntVar(&d.boskosProjectsRequested, "projects-requested", 1, "Number of projects to request from boskos. It is only respected if projects is empty, and must be larger than zero ")
+
 	return flags
 }
 
@@ -223,56 +240,88 @@ func (d *deployer) Up() error {
 	if err := d.init(); err != nil {
 		return err
 	}
-	if err := d.prepareGcpIfNeeded(); err != nil {
+
+	// Only run prepare once for the first GCP project.
+	if err := d.prepareGcpIfNeeded(d.projects[0]); err != nil {
+		return err
+	}
+	if err := d.createNetwork(); err != nil {
+		return err
+	}
+	if err := d.setupNetwork(); err != nil {
 		return err
 	}
 
-	// Create network if it doesn't exist.
-	if runWithNoOutput(exec.Command("gcloud", "compute", "networks", "describe", d.network,
-		"--project="+d.project,
-		"--format=value(name)")) != nil {
-		// Assume error implies non-existent.
-		log.Printf("Couldn't describe network '%s', assuming it doesn't exist and creating it", d.network)
-		if err := runWithOutput(exec.Command("gcloud", "compute", "networks", "create", d.network,
-			"--project="+d.project,
-			"--subnet-mode=auto")); err != nil {
-			return err
-		}
-	}
-
+	klog.V(1).Infof("Environment: %v", os.Environ())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	eg, ctx := errgroup.WithContext(ctx)
 	loc, err := d.location()
 	if err != nil {
 		return err
 	}
-	args := make([]string, len(d.createCommand()))
-	copy(args, d.createCommand())
-	args = append(args,
-		"--project="+d.project,
-		loc,
-		"--machine-type="+d.machineType,
-		"--image-type="+image,
-		"--num-nodes="+strconv.Itoa(d.nodes),
-		"--network="+d.network,
-	)
-	fmt.Printf("Environment: %v", os.Environ())
-
-	args = append(args, d.cluster)
-	fmt.Printf("Gcloud command: gcloud %+v", args)
-	if err := runWithOutput(exec.Command("gcloud", args...)); err != nil {
-		return fmt.Errorf("error creating cluster: %v", err)
+	for i := range d.projects {
+		project := d.projects[i]
+		subNetworkArgs := subNetworkArgs(d.projects, d.region, d.network, i)
+		for j := range d.projectClustersLayout[project] {
+			cluster := d.projectClustersLayout[project][j]
+			eg.Go(func() error {
+				// Create the cluster
+				args := make([]string, len(d.createCommand()))
+				copy(args, d.createCommand())
+				args = append(args,
+					"--project="+project,
+					loc,
+					"--machine-type="+d.machineType,
+					"--image-type="+image,
+					"--num-nodes="+strconv.Itoa(d.nodes),
+					"--network="+transformNetworkName(d.projects, d.network),
+				)
+				args = append(args, subNetworkArgs...)
+				args = append(args, cluster)
+				klog.V(1).Infof("Gcloud command: gcloud %+v\n", args)
+				if err := runWithOutput(exec.CommandWithContext(ctx, "gcloud", args...)); err != nil {
+					// Cancel the context to kill other cluster creation processes if any error happens.
+					cancel()
+					return fmt.Errorf("error creating cluster: %v", err)
+				}
+				return nil
+			})
+		}
 	}
+
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
 func (d *deployer) IsUp() (up bool, err error) {
-	// naively assume that if the api server reports nodes, the cluster is up
-	lines, err := exec.CombinedOutputLines(
-		exec.Command("kubectl", "get", "nodes", "-o=name"),
-	)
-	if err != nil {
-		return false, metadata.NewJUnitError(err, strings.Join(lines, "\n"))
+	if err := d.prepareGcpIfNeeded(d.projects[0]); err != nil {
+		return false, err
 	}
-	return len(lines) > 0, nil
+
+	for _, project := range d.projects {
+		for _, cluster := range d.projectClustersLayout[project] {
+			if err := d.getClusterCredentials(project, cluster); err != nil {
+				return false, err
+			}
+
+			// naively assume that if the api server reports nodes, the cluster is up
+			lines, err := exec.CombinedOutputLines(
+				exec.Command("kubectl", "get", "nodes", "-o=name"),
+			)
+			if err != nil {
+				return false, metadata.NewJUnitError(err, strings.Join(lines, "\n"))
+			}
+			if len(lines) == 0 {
+				return false, fmt.Errorf("project had no nodes active: %s", project)
+			}
+		}
+	}
+
+	return true, nil
 }
 
 // DumpClusterLogs for GKE generates a small script that wraps
@@ -305,32 +354,40 @@ export KUBERNETES_PROVIDER=gke
 export KUBE_NODE_OS_DISTRIBUTION='%[3]s'
 %[5]s
 `
-	// Prevent an obvious injection.
-	if strings.Contains(d.localLogsDir, "'") || strings.Contains(d.gcsLogsDir, "'") {
-		return fmt.Errorf("%q or %q contain single quotes - nice try", d.localLogsDir, d.gcsLogsDir)
+	for _, project := range d.projects {
+		// Prevent an obvious injection.
+		if strings.Contains(d.localLogsDir, "'") || strings.Contains(d.gcsLogsDir, "'") {
+			return fmt.Errorf("%q or %q contain single quotes - nice try", d.localLogsDir, d.gcsLogsDir)
+		}
+
+		// Generate a slice of filters to be OR'd together below
+		var filters []string
+		for _, cluster := range d.projectClustersLayout[project] {
+			if err := d.getInstanceGroups(); err != nil {
+				return err
+			}
+			for _, ig := range d.instanceGroups[project][cluster] {
+				filters = append(filters, fmt.Sprintf("(metadata.created-by:*%s)", ig.path))
+			}
+		}
+
+		// Generate the log-dump.sh command-line
+		dumpCmd := fmt.Sprintf("./cluster/log-dump/log-dump.sh '%s'", d.localLogsDir)
+		if d.gcsLogsDir != "" {
+			dumpCmd += " " + d.gcsLogsDir
+		}
+
+		if err := runWithOutput(exec.Command("bash", "-c", fmt.Sprintf(gkeLogDumpTemplate,
+			project,
+			d.zone,
+			os.Getenv("NODE_OS_DISTRIBUTION"),
+			strings.Join(filters, " OR "),
+			dumpCmd))); err != nil {
+			return err
+		}
 	}
 
-	// Generate a slice of filters to be OR'd together below
-	if err := d.getInstanceGroups(); err != nil {
-		return err
-	}
-	var filters []string
-	for _, ig := range d.instanceGroups {
-		filters = append(filters, fmt.Sprintf("(metadata.created-by:*%s)", ig.path))
-	}
-
-	// Generate the log-dump.sh command-line
-	dumpCmd := fmt.Sprintf("./cluster/log-dump/log-dump.sh '%s'", d.localLogsDir)
-	if d.gcsLogsDir != "" {
-		dumpCmd += " " + d.gcsLogsDir
-	}
-
-	return runWithOutput(exec.Command("bash", "-c", fmt.Sprintf(gkeLogDumpTemplate,
-		d.project,
-		d.zone,
-		os.Getenv("NODE_OS_DISTRIBUTION"),
-		strings.Join(filters, " OR "),
-		dumpCmd)))
+	return nil
 }
 
 func (d *deployer) TestSetup() error {
@@ -338,14 +395,24 @@ func (d *deployer) TestSetup() error {
 		// Ensure setup is a singleton.
 		return nil
 	}
+
+	// Only run prepare once for the first GCP project.
+	if err := d.prepareGcpIfNeeded(d.projects[0]); err != nil {
+		return err
+	}
 	if _, err := d.Kubeconfig(); err != nil {
 		return err
 	}
-	if err := d.getInstanceGroups(); err != nil {
-		return err
-	}
-	if err := d.ensureFirewall(); err != nil {
-		return err
+
+	for _, project := range d.projects {
+		for _, cluster := range d.projectClustersLayout[project] {
+			if err := d.getInstanceGroups(); err != nil {
+				return err
+			}
+			if err := d.ensureFirewall(project, cluster, d.network); err != nil {
+				return err
+			}
+		}
 	}
 	d.testPrepared = true
 	return nil
@@ -355,10 +422,6 @@ func (d *deployer) TestSetup() error {
 // a temp directory, creating one if one does not exist.
 // It also sets the KUBECONFIG environment variable appropriately.
 func (d *deployer) Kubeconfig() (string, error) {
-	if err := d.prepareGcpIfNeeded(); err != nil {
-		return "", err
-	}
-
 	if d.kubecfgPath != "" {
 		return d.kubecfgPath, nil
 	}
@@ -368,42 +431,43 @@ func (d *deployer) Kubeconfig() (string, error) {
 		return "", err
 	}
 
-	// Get gcloud to create the file.
-	loc, err := d.location()
-	if err != nil {
-		return "", err
+	kubecfgFiles := make([]string, 0)
+	for _, project := range d.projects {
+		for _, cluster := range d.projectClustersLayout[project] {
+			filename := filepath.Join(tmpdir, fmt.Sprintf("kubecfg-%s-%s", project, cluster))
+			if err := os.Setenv("KUBECONFIG", filename); err != nil {
+				return "", err
+			}
+			if err := d.getClusterCredentials(project, cluster); err != nil {
+				return "", err
+			}
+			kubecfgFiles = append(kubecfgFiles, filename)
+		}
 	}
 
-	filename := filepath.Join(tmpdir, "kubecfg")
-	if err := os.Setenv("KUBECONFIG", filename); err != nil {
-		return "", err
-	}
-	if err := runWithOutput(exec.Command("gcloud", d.containerArgs("clusters", "get-credentials", d.cluster, "--project="+d.project, loc)...)); err != nil {
-		return "", fmt.Errorf("error executing get-credentials: %v", err)
-	}
-	d.kubecfgPath = filename
+	d.kubecfgPath = strings.Join(kubecfgFiles, string(os.PathListSeparator))
 	return d.kubecfgPath, nil
 }
 
-func (d *deployer) ensureFirewall() error {
-	if d.network == "default" {
+func (d *deployer) ensureFirewall(project, cluster, network string) error {
+	if network == "default" {
 		return nil
 	}
-	firewall, err := d.getClusterFirewall()
+	firewall, err := d.getClusterFirewall(project, cluster)
 	if err != nil {
 		return fmt.Errorf("error getting unique firewall: %v", err)
 	}
 	if runWithNoOutput(exec.Command("gcloud", "compute", "firewall-rules", "describe", firewall,
-		"--project="+d.project,
+		"--project="+project,
 		"--format=value(name)")) == nil {
 		// Assume that if this unique firewall exists, it's good to go.
 		return nil
 	}
-	log.Printf("Couldn't describe firewall '%s', assuming it doesn't exist and creating it", firewall)
+	klog.V(1).Infof("Couldn't describe firewall '%s', assuming it doesn't exist and creating it", firewall)
 
 	tagOut, err := exec.Output(exec.Command("gcloud", "compute", "instances", "list",
-		"--project="+d.project,
-		"--filter=metadata.created-by:*"+d.instanceGroups[0].path,
+		"--project="+project,
+		"--filter=metadata.created-by:*"+d.instanceGroups[project][cluster][0].path,
 		"--limit=1",
 		"--format=get(tags.items)"))
 	if err != nil {
@@ -415,8 +479,8 @@ func (d *deployer) ensureFirewall() error {
 	}
 
 	if err := runWithOutput(exec.Command("gcloud", "compute", "firewall-rules", "create", firewall,
-		"--project="+d.project,
-		"--network="+d.network,
+		"--project="+project,
+		"--network="+network,
 		"--allow="+e2eAllow,
 		"--target-tags="+tag)); err != nil {
 		return fmt.Errorf("error creating e2e firewall: %v", err)
@@ -425,36 +489,52 @@ func (d *deployer) ensureFirewall() error {
 }
 
 func (d *deployer) getInstanceGroups() error {
-	if len(d.instanceGroups) > 0 {
+	if d.instanceGroups != nil {
 		return nil
 	}
+
+	// Initialize project instance groups structure
+	d.instanceGroups = map[string]map[string][]*ig{}
+
 	location, err := d.location()
 	if err != nil {
 		return err
 	}
-	igs, err := exec.Output(exec.Command("gcloud", d.containerArgs("clusters", "describe", d.cluster,
-		"--format=value(instanceGroupUrls)",
-		"--project="+d.project,
-		location)...))
-	if err != nil {
-		return fmt.Errorf("instance group URL fetch failed: %s", execError(err))
-	}
-	igURLs := strings.Split(strings.TrimSpace(string(igs)), ";")
-	if len(igURLs) == 0 {
-		return fmt.Errorf("no instance group URLs returned by gcloud, output %q", string(igs))
-	}
-	sort.Strings(igURLs)
-	for _, igURL := range igURLs {
-		m := poolRe.FindStringSubmatch(igURL)
-		if len(m) == 0 {
-			return fmt.Errorf("instanceGroupUrl %q did not match regex %v", igURL, poolRe)
+
+	for _, project := range d.projects {
+		d.instanceGroups[project] = map[string][]*ig{}
+
+		for _, cluster := range d.projectClustersLayout[project] {
+			igs, err := exec.Output(exec.Command("gcloud", d.containerArgs("clusters", "describe", cluster,
+				"--format=value(instanceGroupUrls)",
+				"--project="+project,
+				location)...))
+			if err != nil {
+				return fmt.Errorf("instance group URL fetch failed: %s", execError(err))
+			}
+			igURLs := strings.Split(strings.TrimSpace(string(igs)), ";")
+			if len(igURLs) == 0 {
+				return fmt.Errorf("no instance group URLs returned by gcloud, output %q", string(igs))
+			}
+			sort.Strings(igURLs)
+
+			// Inialize cluster instance groups
+			d.instanceGroups[project][cluster] = make([]*ig, 0)
+
+			for _, igURL := range igURLs {
+				m := poolRe.FindStringSubmatch(igURL)
+				if len(m) == 0 {
+					return fmt.Errorf("instanceGroupUrl %q did not match regex %v", igURL, poolRe)
+				}
+				d.instanceGroups[project][cluster] = append(d.instanceGroups[project][cluster], &ig{path: m[0], zone: m[1], name: m[2], uniq: m[3]})
+			}
 		}
-		d.instanceGroups = append(d.instanceGroups, &ig{path: m[0], zone: m[1], name: m[2], uniq: m[3]})
 	}
+
 	return nil
 }
 
-func (d *deployer) getClusterFirewall() (string, error) {
+func (d *deployer) getClusterFirewall(project, cluster string) (string, error) {
 	if err := d.getInstanceGroups(); err != nil {
 		return "", err
 	}
@@ -462,25 +542,25 @@ func (d *deployer) getClusterFirewall() (string, error) {
 	// that maps to the cluster nodes, but the target tag for the
 	// nodes can be slow to get. Use the hash from the lexically first
 	// node pool instead.
-	return "e2e-ports-" + d.instanceGroups[0].uniq, nil
+	return "e2e-ports-" + d.instanceGroups[project][cluster][0].uniq, nil
 }
 
 // This function ensures that all firewall-rules are deleted from specific network.
 // We also want to keep in logs that there were some resources leaking.
-func (d *deployer) cleanupNetworkFirewalls() (int, error) {
+func (d *deployer) cleanupNetworkFirewalls(project, network string) (int, error) {
 	fws, err := exec.Output(exec.Command("gcloud", "compute", "firewall-rules", "list",
 		"--format=value(name)",
-		"--project="+d.project,
-		"--filter=network:"+d.network))
+		"--project="+project,
+		"--filter=network:"+network))
 	if err != nil {
 		return 0, fmt.Errorf("firewall rules list failed: %s", execError(err))
 	}
 	if len(fws) > 0 {
 		fwList := strings.Split(strings.TrimSpace(string(fws)), "\n")
-		log.Printf("Network %s has %v undeleted firewall rules %v", d.network, len(fwList), fwList)
+		klog.V(1).Infof("Network %s has %v undeleted firewall rules %v", network, len(fwList), fwList)
 		commandArgs := []string{"compute", "firewall-rules", "delete", "-q"}
 		commandArgs = append(commandArgs, fwList...)
-		commandArgs = append(commandArgs, "--project="+d.project)
+		commandArgs = append(commandArgs, "--project="+project)
 		errFirewall := runWithOutput(exec.Command("gcloud", commandArgs...))
 		if errFirewall != nil {
 			return 0, fmt.Errorf("error deleting firewall: %v", errFirewall)
@@ -494,67 +574,97 @@ func (d *deployer) Down() error {
 	if err := d.init(); err != nil {
 		return err
 	}
-	if err := d.prepareGcpIfNeeded(); err != nil {
+
+	if err := d.prepareGcpIfNeeded(d.projects[0]); err != nil {
 		return err
 	}
-	firewall, err := d.getClusterFirewall()
-	if err != nil {
-		// This is expected if the cluster doesn't exist.
-		return nil
-	}
-	d.instanceGroups = nil
 
+	var wg sync.WaitGroup
+	for i := range d.projects {
+		project := d.projects[i]
+		for j := range d.projectClustersLayout[project] {
+			cluster := d.clusters[j]
+			firewall, err := d.getClusterFirewall(project, cluster)
+			if err != nil {
+				// This is expected if the cluster doesn't exist.
+				continue
+			}
+			d.instanceGroups = nil
+
+			loc, err := d.location()
+			if err != nil {
+				return err
+			}
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				// We best-effort try all of these and report errors as appropriate.
+				errCluster := runWithOutput(exec.Command(
+					"gcloud", d.containerArgs("clusters", "delete", "-q", cluster,
+						"--project="+project,
+						loc)...))
+
+				// don't delete default network
+				if d.network == "default" {
+					if errCluster != nil {
+						klog.V(1).Infof("Error deleting cluster using default network, allow the error for now %s", errCluster)
+					}
+					return
+				}
+
+				var errFirewall error
+				if runWithNoOutput(exec.Command("gcloud", "compute", "firewall-rules", "describe", firewall,
+					"--project="+project,
+					"--format=value(name)")) == nil {
+					klog.V(1).Infof("Found rules for firewall '%s', deleting them", firewall)
+					errFirewall = exec.Command("gcloud", "compute", "firewall-rules", "delete", "-q", firewall,
+						"--project="+project).Run()
+				} else {
+					klog.V(1).Infof("Found no rules for firewall '%s', assuming resources are clean", firewall)
+				}
+				numLeakedFWRules, errCleanFirewalls := d.cleanupNetworkFirewalls(project, d.network)
+
+				if errCluster != nil {
+					klog.Errorf("error deleting cluster: %v", errCluster)
+				}
+				if errFirewall != nil {
+					klog.Errorf("error deleting firewall: %v", errFirewall)
+				}
+				if errCleanFirewalls != nil {
+					klog.Errorf("error cleaning-up firewalls: %v", errCleanFirewalls)
+				}
+				if numLeakedFWRules > 0 {
+					klog.Errorf("leaked firewall rules")
+				}
+			}()
+		}
+	}
+	wg.Wait()
+
+	if err := d.teardownNetwork(); err != nil {
+		return err
+	}
+	if err := d.deleteNetwork(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *deployer) getClusterCredentials(project, cluster string) error {
+	// Get gcloud to create the file.
 	loc, err := d.location()
 	if err != nil {
 		return err
 	}
 
-	// We best-effort try all of these and report errors as appropriate.
-	errCluster := runWithOutput(exec.Command(
-		"gcloud", d.containerArgs("clusters", "delete", "-q", d.cluster,
-			"--project="+d.project,
-			loc)...))
-
-	// don't delete default network
-	if d.network == "default" {
-		if errCluster != nil {
-			log.Printf("Error deleting cluster using default network, allow the error for now %s", errCluster)
-		}
-		return nil
+	if err := runWithOutput(exec.Command("gcloud",
+		d.containerArgs("clusters", "get-credentials", cluster, "--project="+project, loc)...),
+	); err != nil {
+		return fmt.Errorf("error executing get-credentials: %v", err)
 	}
 
-	var errFirewall error
-	if runWithNoOutput(exec.Command("gcloud", "compute", "firewall-rules", "describe", firewall,
-		"--project="+d.project,
-		"--format=value(name)")) == nil {
-		log.Printf("Found rules for firewall '%s', deleting them", firewall)
-		errFirewall = exec.Command("gcloud", "compute", "firewall-rules", "delete", "-q", firewall,
-			"--project="+d.project).Run()
-	} else {
-		log.Printf("Found no rules for firewall '%s', assuming resources are clean", firewall)
-	}
-	numLeakedFWRules, errCleanFirewalls := d.cleanupNetworkFirewalls()
-	var errSubnet error
-	errNetwork := runWithOutput(exec.Command("gcloud", "compute", "networks", "delete", "-q", d.network,
-		"--project="+d.project))
-	if errCluster != nil {
-		return fmt.Errorf("error deleting cluster: %v", errCluster)
-	}
-	if errFirewall != nil {
-		return fmt.Errorf("error deleting firewall: %v", errFirewall)
-	}
-	if errCleanFirewalls != nil {
-		return fmt.Errorf("error cleaning-up firewalls: %v", errCleanFirewalls)
-	}
-	if errSubnet != nil {
-		return fmt.Errorf("error deleting subnetwork: %v", errSubnet)
-	}
-	if errNetwork != nil {
-		return fmt.Errorf("error deleting network: %v", errNetwork)
-	}
-	if numLeakedFWRules > 0 {
-		return fmt.Errorf("leaked firewall rules")
-	}
 	return nil
 }
 

--- a/kubetest2-gke/deployer/network.go
+++ b/kubetest2-gke/deployer/network.go
@@ -1,0 +1,337 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"k8s.io/klog"
+
+	"sigs.k8s.io/kubetest2/pkg/exec"
+)
+
+const networkUserPolicyTemplate = `
+bindings:
+- members:
+  - serviceAccount:%s
+  - serviceAccount:%s
+  role: roles/compute.networkUser
+etag: %s
+`
+
+func (d *deployer) verifyNetworkFlags() error {
+	// For single project, no verification is needed.
+	if len(d.projects) == 1 {
+		return nil
+	}
+
+	if d.network == "default" {
+		return errors.New("the default network cannot be used for multi-project profile")
+	}
+
+	if len(d.subnetworkRanges) != len(d.projects)-1 {
+		return fmt.Errorf("the number of subnetwork ranges provided "+
+			"should be the same as the number of service projects: %d!=%d", len(d.subnetworkRanges), len(d.projects)-1)
+	}
+
+	for _, sr := range d.subnetworkRanges {
+		parts := strings.Split(sr, " ")
+		if len(parts) != 3 {
+			return fmt.Errorf("the provided subnetwork range %s is not in the right format, should be like "+
+				"10.0.4.0/22 10.0.32.0/20 10.4.0.0/14", sr)
+		}
+	}
+
+	return nil
+}
+
+func (d *deployer) createNetwork() error {
+	// Create network if it doesn't exist.
+	// For single project profile, the subnet-mode could be auto for simplicity.
+	// For multiple projects profile, the subnet-mode must be custom and should only be created in the host project.
+	//   (Here we consider the first project to be the host project and the rest be service projects)
+	//   Reference: https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc#creating_a_network_and_two_subnets
+	subnetMode := "auto"
+	if len(d.projects) > 1 {
+		subnetMode = "custom"
+	}
+	if runWithNoOutput(exec.Command("gcloud", "compute", "networks", "describe", d.network,
+		"--project="+d.projects[0],
+		"--format=value(name)")) != nil {
+		// Assume error implies non-existent.
+		// TODO(chizhg): find a more reliable way to check if the network exists or not.
+		klog.V(1).Infof("Couldn't describe network %q, assuming it doesn't exist and creating it", d.network)
+		if err := runWithOutput(exec.Command("gcloud", "compute", "networks", "create", d.network,
+			"--project="+d.projects[0],
+			"--subnet-mode="+subnetMode)); err != nil {
+			return err
+		}
+	}
+
+	// Create subnetworks for the service projects to work with shared VPC if it's a multi-project profile.
+	// Reference: https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc#creating_a_network_and_two_subnets
+	if len(d.projects) == 1 {
+		return nil
+	}
+	hostProject := d.projects[0]
+	for i, nr := range d.subnetworkRanges {
+		serviceProject := d.projects[i+1]
+		parts := strings.Split(nr, " ")
+		// The subnetwork name is in the format of `[main_network]-[service_project_id]`.
+		subnetName := d.network + "-" + serviceProject
+		if err := runWithOutput(exec.Command("gcloud", "compute", "networks", "subnets", "create",
+			subnetName,
+			"--project="+hostProject,
+			"--region="+d.region,
+			"--network="+d.network,
+			"--range="+parts[0],
+			"--secondary-range",
+			fmt.Sprintf("%s-service=%s,%s-pods=%s", subnetName, parts[1], subnetName, parts[2]),
+		)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *deployer) deleteNetwork() error {
+	// Delete the subnetworks if it's a multi-project profile.
+	// Reference: https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc#deleting_the_shared_network
+	if len(d.projects) >= 1 {
+		hostProject := d.projects[0]
+		for i := 1; i < len(d.projects); i++ {
+			serviceProject := d.projects[i]
+			subnetName := d.network + "-" + serviceProject
+			if err := runWithOutput(exec.Command("gcloud", "compute", "networks", "subnets", "delete",
+				subnetName,
+				"--project="+hostProject,
+				"--region="+d.region,
+			)); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := runWithOutput(exec.Command("gcloud", "compute", "networks", "delete", "-q", d.network,
+		"--project="+d.projects[0])); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func transformNetworkName(projects []string, network string) string {
+	if len(projects) == 1 {
+		return network
+	}
+	// Multiproject should specify the network at cluster creation such as:
+	// projects/HOST_PROJECT_ID/global/networks/SHARED_VPC_NETWORK
+	return fmt.Sprintf("projects/%s/global/networks/%s", projects[0], network)
+}
+
+// Returns the sub network args needed for the cluster creation command.
+// Reference: https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc#creating_a_cluster_in_your_first_service_project
+func subNetworkArgs(projects []string, region, network string, projectIndex int) []string {
+	// No sub network args need to be added for creating clusters in the host project.
+	if projectIndex == 0 {
+		return []string{}
+	}
+
+	// subnetwork args are needed for creating clusters in the service project.
+	hostProject := projects[0]
+	curtProject := projects[projectIndex]
+	subnetName := network + "-" + curtProject
+	return []string{
+		"--enable-ip-alias",
+		fmt.Sprintf("--subnetwork=projects/%s/regions/%s/subnetworks/%s", hostProject, region, subnetName),
+		fmt.Sprintf("--cluster-secondary-range-name=%s-pods", subnetName),
+		fmt.Sprintf("--services-secondary-range-name=%s-services", subnetName),
+	}
+}
+
+func (d *deployer) setupNetwork() error {
+	if err := enableSharedVPCAndGrantRoles(d.projects, d.region, d.network); err != nil {
+		return err
+	}
+	if err := grantHostServiceAgentUserRole(d.projects); err != nil {
+		return err
+	}
+	return nil
+}
+
+// This function implements https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc#enabling_and_granting_roles
+// to enable shared VPC and grant required roles for the multi-project multi-cluster profile.
+func enableSharedVPCAndGrantRoles(projects []string, region, network string) error {
+	// Nothing needs to be done for single project.
+	if len(projects) == 1 {
+		return nil
+	}
+
+	// The host project will enabled a Shared VPC for other projects and clusters
+	// to be part of the same network topology and form a mesh. At current stage,
+	// no particular customization has to be made and a single mesh will cover all
+	// identified use cases.
+
+	// Enable Shared VPC for multiproject requests on the host project.
+	// Assuming we have Shared VPC Admin role at the organization level.
+	networkHostProject := projects[0]
+	if err := runWithOutput(exec.Command("gcloud", "compute", "shared-vpc", "enable", networkHostProject)); err != nil {
+		return fmt.Errorf("error creating Shared VPC host project: %s", err)
+	}
+
+	// Associate the rest of the projects.
+	for i := 1; i < len(projects); i++ {
+		if err := runWithOutput(exec.Command("gcloud", "compute", "shared-vpc",
+			"associated-projects", "add", projects[i],
+			"--host-project", networkHostProject)); err != nil {
+			return fmt.Errorf("error associating project (%s) to Shared VPC: %s", projects[i], err)
+		}
+	}
+
+	// Grant the required IAM roles to service accounts that belong to the service projects.
+	for i := 1; i < len(projects); i++ {
+		serviceProject := projects[1]
+		subnetName := network + "-" + serviceProject
+		// Get the subnet etag.
+		subnetETag, err := exec.Output(exec.Command("gcloud", "compute", "networks", "subnets",
+			"get-iam-policy", subnetName, "--project="+networkHostProject, "--region="+region, "--format=value(etag)"))
+		if err != nil {
+			return fmt.Errorf("failed to get the etag for the subnet: %s %s %v", network, region, err)
+		}
+		// Get the service project number.
+		serviceProjectNum, err := getProjectNumber(serviceProject)
+		if err != nil {
+			return fmt.Errorf("failed to get the project number for %s: %v", serviceProject, err)
+		}
+		gkeServiceAccount := fmt.Sprintf("service-%s@container-engine-robot.iam.gserviceaccount.com", serviceProjectNum)
+		googleAPIServiceAccount := serviceProjectNum + "@cloudservices.gserviceaccount.com"
+
+		// Grant the required IAM roles to service accounts that belong to the service project.
+		tempFile, err := ioutil.TempFile("", "*.yaml")
+		if err != nil {
+			return fmt.Errorf("failed to create a temporary yaml file: %v", err)
+		}
+		policyStr := fmt.Sprintf(networkUserPolicyTemplate, googleAPIServiceAccount, gkeServiceAccount, strings.TrimSpace(string(subnetETag)))
+		if err = ioutil.WriteFile(tempFile.Name(), []byte(policyStr), os.ModePerm); err != nil {
+			return fmt.Errorf("failed to write the content into %s: %v", tempFile.Name(), err)
+		}
+		if err = runWithOutput(exec.Command("gcloud", "compute", "networks", "subnets", "set-iam-policy", subnetName,
+			tempFile.Name(), "--project="+networkHostProject, "--region="+region)); err != nil {
+			return fmt.Errorf("failed to set IAM policy: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// This function implements https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc#grant_host_service_agent_role
+// to grant the Host Service Agent User role to each service project's GKE service account.
+func grantHostServiceAgentUserRole(projects []string) error {
+	// Nothing needs to be done for single project.
+	if len(projects) == 1 {
+		return nil
+	}
+
+	hostProject := projects[0]
+	for i := 1; i < len(projects); i++ {
+		serviceProject := projects[1]
+		serviceProjectNum, err := getProjectNumber(serviceProject)
+		if err != nil {
+			return err
+		}
+
+		gkeServiceAccount := fmt.Sprintf("service-%s@container-engine-robot.iam.gserviceaccount.com", serviceProjectNum)
+		if err = runWithOutput(exec.Command("gcloud", "projects", "add-iam-policy-binding", hostProject,
+			"--member=serviceAccount:"+gkeServiceAccount,
+			"--role=roles/container.hostServiceAgentUser")); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *deployer) teardownNetwork() error {
+	if err := disableSharedVPCProjects(d.projects); err != nil {
+		return err
+	}
+	if err := removeHostServiceAgentUserRole(d.projects); err != nil {
+		return err
+	}
+	return nil
+}
+
+func disableSharedVPCProjects(projects []string) error {
+	// Nothing needs to be done for single project.
+	if len(projects) == 1 {
+		return nil
+	}
+
+	// The host project will enabled a Shared VPC for other projects and clusters
+	// to be part of the same network topology and form a mesh. At current stage,
+	// no particular customization has to be made and a single mesh will cover all
+	// identified use cases
+
+	// Assuming we have Shared VPC Admin role at the organization level
+	networkHostProject := projects[0]
+
+	// Disassociate the rest of the projects
+	for i := 1; i < len(projects); i++ {
+		if err := runWithOutput(exec.Command("gcloud", "compute", "shared-vpc",
+			"associated-projects", "remove", projects[i],
+			"--host-project", networkHostProject)); err != nil {
+			return fmt.Errorf("error associating project (%s) to Shared VPC: %s", projects[i], err)
+		}
+	}
+
+	// Disable Shared VPC for multiproject requests on the host project
+	if err := runWithOutput(exec.Command("gcloud", "compute", "shared-vpc", "disable", networkHostProject)); err != nil {
+		return fmt.Errorf("error creating Shared VPC host project: %s", err)
+	}
+
+	return nil
+}
+
+// This function implements https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc#removing_the_host_service_agent_user_role
+// to remove the Host Service Agent User role granted to each service project's GKE service account.
+func removeHostServiceAgentUserRole(projects []string) error {
+	// Nothing needs to be done for single project.
+	if len(projects) == 1 {
+		return nil
+	}
+
+	hostProject := projects[0]
+	for i := 1; i < len(projects); i++ {
+		serviceProject := projects[1]
+		serviceProjectNum, err := getProjectNumber(serviceProject)
+		if err != nil {
+			return err
+		}
+
+		gkeServiceAccount := fmt.Sprintf("service-%s@container-engine-robot.iam.gserviceaccount.com", serviceProjectNum)
+		if err = runWithOutput(exec.Command("gcloud", "projects", "remove-iam-policy-binding", hostProject,
+			"--member=serviceAccount:"+gkeServiceAccount,
+			"--role=roles/container.hostServiceAgentUser")); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -19,6 +19,7 @@ package exec
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"io"
 	"io/ioutil"
 	"os"
@@ -51,6 +52,10 @@ var DefaultCmder = &LocalCmder{}
 // Command is a convience wrapper over DefaultCmder.Command
 func Command(command string, args ...string) Cmd {
 	return DefaultCmder.Command(command, args...)
+}
+
+func CommandWithContext(ctx context.Context, command string, args ...string) Cmd {
+	return DefaultCmder.CommandWithContext(ctx, command, args...)
 }
 
 // Output is for compatibility with cmd.Output.

--- a/pkg/exec/local.go
+++ b/pkg/exec/local.go
@@ -17,6 +17,7 @@ limitations under the License.
 package exec
 
 import (
+	"context"
 	"io"
 	osexec "os/exec"
 )
@@ -37,6 +38,13 @@ var _ Cmder = &LocalCmder{}
 func (c *LocalCmder) Command(name string, arg ...string) Cmd {
 	return &LocalCmd{
 		Cmd: osexec.Command(name, arg...),
+	}
+}
+
+// CommandWithContext returns a new exec.Cmd with the context, backed by Cmd
+func (c *LocalCmder) CommandWithContext(ctx context.Context, name string, arg ...string) Cmd {
+	return &LocalCmd{
+		Cmd: osexec.CommandContext(ctx, name, arg...),
 	}
 }
 


### PR DESCRIPTION
--project and --cluster-name parameters have been modified to accept a list of projects and cluster. This change respects previous functionality with only one project and one cluster. On multi-project cases, cluster names do have to end with "-X", being X a 0-based index to which project they should belong. No other dash character is allowed in the cluster name for parsing purposes and the final cluster name will filter out this indexing postfix.

--projects-requested=int has been included to request N projects from Boskos

Internal data structures keep track of the relations between projects and clusters and the difference instance groups

Network parameter is kept as a single element. On one project cases, it's the network used and on multi-project cases, it is the name of the Shared VPC network that will be created on the first project and to which the rest of the projects will be linked with.

Changed default environment from 'staging' to 'prod'

Succesful regression test performed:
$ go run ~/go/src/github.com/kubernetes-sigs/kubetest2/kubetest2-gke --up --down --num-nodes=1 --project=test-project --cluster-name=testcluster --zone=us-central1-a --network=test-network