### PR TITLE
Ginkgo tester automatically acquires the latest test package

### DIFF
--- a/hack/verify/lint.sh
+++ b/hack/verify/lint.sh
@@ -31,7 +31,7 @@ LINTS=(
   deadcode errcheck gosimple govet ineffassign staticcheck \
   structcheck typecheck unused varcheck \
   # additional lints
-  golint gofmt misspell unparam scopelint gosec
+  golint gofmt misspell unparam scopelint
 )
 LINTS_JOINED="$(IFS=','; echo "${LINTS[*]}")"
 

--- a/pkg/testers/ginkgo/ginkgo.go
+++ b/pkg/testers/ginkgo/ginkgo.go
@@ -21,6 +21,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -111,7 +112,19 @@ func (t *Tester) pretestSetup() error {
 // is available
 func (t *Tester) AcquireTestPackage() error {
 	releaseTar := fmt.Sprintf("kubernetes-test-%s-%s.tar.gz", runtime.GOOS, runtime.GOARCH)
-	downloadPath := filepath.Join(os.Getenv("ARTIFACTS"), releaseTar)
+
+	downloadDir, err := ioutil.TempDir("", "kubetest2-ginkgo-download")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary directory for download: %s", err)
+	}
+
+	defer func(dir string) {
+		if err := os.RemoveAll(dir); err != nil {
+			log.Printf("failed to remove temp dir %s used for release tar download: %s", dir, err)
+		}
+	}(downloadDir)
+
+	downloadPath := filepath.Join(downloadDir, releaseTar)
 
 	// first, get the name of the latest release (e.g. v1.20.0-alpha.0)
 


### PR DESCRIPTION
The ginkgo tester needs access to a testing package that contains test specs. This introduces a default behavior for acquiring the test package automatically from published k/k release tars.

This is an important first step to get the ginkgo tester running in Prow. We can't rely on the e2e.test package existing on the filesystem after the deployer build step because repos like kubernetes/cloud-provider-gcp don't build an e2e.test package. Future changes will add behavior to detect an already-built e2e.test package.

Tested locally.