### PR TITLE
Also print out the usage for the deployer if no args are provided

### DIFF
--- a/pkg/app/cmd.go
+++ b/pkg/app/cmd.go
@@ -129,15 +129,13 @@ func runE(
 	allFlags := pflag.NewFlagSet(deployerName, pflag.ContinueOnError)
 	allFlags.AddFlagSet(kubetest2Flags)
 	allFlags.AddFlagSet(deployerFlags)
-	if err := allFlags.Parse(deployerArgs); err != nil {
+	if err := allFlags.Parse(deployerArgs); err != nil && parseError == nil {
 		// NOTE: we only retain the first parse error currently, and handle below
-		if err != nil && parseError == nil {
-			parseError = err
-		}
+		parseError = err
 	}
 
-	// print usage and return if explicitly requested
-	if opts.HelpRequested() {
+	// print usage and return if no args are provided, or help is explicitly requested
+	if len(args) == 0 || opts.HelpRequested() {
 		cmd.Print(usage.String())
 		return nil
 	}


### PR DESCRIPTION
1. It's better to also print out the usage for the deployer if no args provided, like for `kubetest2 gke`, as this is the "default" behavior for most command line tools.

2. Also by the way made a small cosmetic change near the above change.

/cc @amwat @BenTheElder 