### PR TITLE
Add flags to GCE deployer to set cache mutation detector, runtime config, create custom network, and enable pod security policy

### DIFF
--- a/kubetest2-gce/deployer/common.go
+++ b/kubetest2-gce/deployer/common.go
@@ -143,6 +143,14 @@ func (d *deployer) buildEnv() []string {
 		env = append(env, fmt.Sprintf("KUBE_RUNTIME_CONFIG=%s", d.RuntimeConfig))
 	}
 
+	if d.EnablePodSecurityPolicy {
+		env = append(env, "ENABLE_POD_SECURITY_POLICY=true")
+	}
+
+	if d.CreateCustomNetwork {
+		env = append(env, "CREATE_CUSTOM_NETWORK=true")
+	}
+
 	return env
 }
 

--- a/kubetest2-gce/deployer/common.go
+++ b/kubetest2-gce/deployer/common.go
@@ -135,6 +135,14 @@ func (d *deployer) buildEnv() []string {
 	env = append(env, fmt.Sprintf("NUM_NODES=%d", d.NumNodes))
 	env = append(env, fmt.Sprintf("CLUSTER_IP_RANGE=%s", getClusterIPRange(d.NumNodes)))
 
+	if d.EnableCacheMutationDetector {
+		env = append(env, "ENABLE_CACHE_MUTATION_DETECTOR=true")
+	}
+
+	if d.RuntimeConfig != "" {
+		env = append(env, fmt.Sprintf("KUBE_RUNTIME_CONFIG=%s", d.RuntimeConfig))
+	}
+
 	return env
 }
 

--- a/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2-gce/deployer/deployer.go
@@ -65,6 +65,8 @@ type deployer struct {
 	BoskosLocation              string `desc:"If set, manually specifies the location of the boskos server. If unset and boskos is needed, defaults to http://boskos.test-pods.svc.cluster.local."`
 	LegacyMode                  bool   `desc:"Set if the provided repo root is the kubernetes/kubernetes repo and not kubernetes/cloud-provider-gcp."`
 	NumNodes                    int    `desc:"The number of nodes in the cluster."`
+	EnableCacheMutationDetector bool   `desc:"Sets the environment variable ENABLE_CACHE_MUTATION_DETECTOR=true during deployment."`
+	RuntimeConfig               string `desc:"Sets the KUBE_RUNTIME_CONFIG environment variable during deployment."`
 }
 
 // New implements deployer.New for gce

--- a/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2-gce/deployer/deployer.go
@@ -65,8 +65,11 @@ type deployer struct {
 	BoskosLocation              string `desc:"If set, manually specifies the location of the boskos server. If unset and boskos is needed, defaults to http://boskos.test-pods.svc.cluster.local."`
 	LegacyMode                  bool   `desc:"Set if the provided repo root is the kubernetes/kubernetes repo and not kubernetes/cloud-provider-gcp."`
 	NumNodes                    int    `desc:"The number of nodes in the cluster."`
+
 	EnableCacheMutationDetector bool   `desc:"Sets the environment variable ENABLE_CACHE_MUTATION_DETECTOR=true during deployment. This should cause a panic if anything mutates a shared informer cache."`
 	RuntimeConfig               string `desc:"Sets the KUBE_RUNTIME_CONFIG environment variable during deployment."`
+	EnablePodSecurityPolicy     bool   `desc:"Sets the environment variable ENABLE_POD_SECURITY_POLICY=true during deployment."`
+	CreateCustomNetwork         bool   `desc:"Sets the environment variable CREATE_CUSTOM_NETWORK=true during deployment."`
 }
 
 // New implements deployer.New for gce

--- a/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2-gce/deployer/deployer.go
@@ -65,7 +65,7 @@ type deployer struct {
 	BoskosLocation              string `desc:"If set, manually specifies the location of the boskos server. If unset and boskos is needed, defaults to http://boskos.test-pods.svc.cluster.local."`
 	LegacyMode                  bool   `desc:"Set if the provided repo root is the kubernetes/kubernetes repo and not kubernetes/cloud-provider-gcp."`
 	NumNodes                    int    `desc:"The number of nodes in the cluster."`
-	EnableCacheMutationDetector bool   `desc:"Sets the environment variable ENABLE_CACHE_MUTATION_DETECTOR=true during deployment."`
+	EnableCacheMutationDetector bool   `desc:"Sets the environment variable ENABLE_CACHE_MUTATION_DETECTOR=true during deployment. This should cause a panic if anything mutates a shared informer cache."`
 	RuntimeConfig               string `desc:"Sets the KUBE_RUNTIME_CONFIG environment variable during deployment."`
 }
 


### PR DESCRIPTION
These flags are part of the necessary features to support a drop-in replacement (using kubetest2) of the merge-blocking job pull-kubernetes-e2e-gce. See https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml#L37 for the original job spec.