### PR TITLE
Ginkgo tester has flag report-dir set to ARTIFACTS

### DIFF
--- a/pkg/testers/ginkgo/ginkgo.go
+++ b/pkg/testers/ginkgo/ginkgo.go
@@ -65,6 +65,7 @@ func (t *Tester) Test() error {
 		"--ginkgo.flakeAttempts=" + strconv.Itoa(t.FlakeAttempts),
 		"--ginkgo.skip=" + t.SkipRegex,
 		"--ginkgo.focus=" + t.FocusRegex,
+		"--report-dir=" + os.Getenv("ARTIFACTS"),
 	}
 	ginkgoArgs := append([]string{
 		"--nodes=" + strconv.Itoa(t.Parallel),


### PR DESCRIPTION
This will create the junit test output files that testgrid needs to show higher-resolution test feedback. Verified the creation of test output files using mkpj and mkpod on a GKE cluster. Verified that $ARTIFACTS is the correct location for these files by referencing uploaded artifacts directories for other jobs.