### PR TITLE
Fix the logic to verify network configs when boskos is used

### DIFF
--- a/kubetest2-gke/deployer/deployer.go
+++ b/kubetest2-gke/deployer/deployer.go
@@ -141,10 +141,13 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 
 // verifyCommonFlags validates flags for up phase.
 func (d *deployer) verifyUpFlags() error {
+	if len(d.projects) == 0 && d.boskosProjectsRequested <= 0 {
+		return fmt.Errorf("either --project or --projects-requested with a value larger than 0 must be set for GKE deployment")
+	}
 	if err := d.verifyNetworkFlags(); err != nil {
 		return err
 	}
-	if d.clusters == nil {
+	if len(d.clusters) == 0 {
 		return fmt.Errorf("--cluster-name must be set for GKE deployment")
 	}
 	if _, err := d.location(); err != nil {
@@ -158,10 +161,10 @@ func (d *deployer) verifyUpFlags() error {
 
 // verifyDownFlags validates flags for down phase.
 func (d *deployer) verifyDownFlags() error {
-	if d.clusters == nil {
+	if len(d.clusters) == 0 {
 		return fmt.Errorf("--cluster-name must be set for GKE deployment")
 	}
-	if d.projects == nil {
+	if len(d.projects) == 0 {
 		return fmt.Errorf("--project must be set for GKE deployment")
 	}
 	if _, err := d.location(); err != nil {

--- a/kubetest2-gke/deployer/network.go
+++ b/kubetest2-gke/deployer/network.go
@@ -39,7 +39,11 @@ etag: %s
 
 func (d *deployer) verifyNetworkFlags() error {
 	// For single project, no verification is needed.
-	if len(d.projects) == 1 {
+	numProjects := len(d.projects)
+	if numProjects == 0 {
+		numProjects = d.boskosProjectsRequested
+	}
+	if numProjects == 1 {
 		return nil
 	}
 
@@ -47,9 +51,9 @@ func (d *deployer) verifyNetworkFlags() error {
 		return errors.New("the default network cannot be used for multi-project profile")
 	}
 
-	if len(d.subnetworkRanges) != len(d.projects)-1 {
+	if len(d.subnetworkRanges) != numProjects-1 {
 		return fmt.Errorf("the number of subnetwork ranges provided "+
-			"should be the same as the number of service projects: %d!=%d", len(d.subnetworkRanges), len(d.projects)-1)
+			"should be the same as the number of service projects: %d!=%d", len(d.subnetworkRanges), numProjects-1)
 	}
 
 	for _, sr := range d.subnetworkRanges {


### PR DESCRIPTION
Fix the logic in `verifyNetworkFlags` to also skip the network verification if users only request one single boskos project. Also make some changes in verifying `projects` and `clusters` as we changed them to be arrays.

/cc @amwat 