### PR TITLE
Make boskos resource type configurable and GCP SSH key not required

### DIFF
--- a/kubetest2-gke/deployer/commandutils.go
+++ b/kubetest2-gke/deployer/commandutils.go
@@ -47,7 +47,6 @@ func (d *deployer) prepareGcpIfNeeded(projectID string) error {
 		return fmt.Errorf("--environment must be one of {test,staging,staging2,prod} or match %v, found %q", urlRe, env)
 	}
 
-	//TODO(RonWeber): boskos
 	if err := os.Setenv("CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS", "1"); err != nil {
 		return fmt.Errorf("could not set CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS=1: %v", err)
 	}
@@ -64,15 +63,17 @@ func (d *deployer) prepareGcpIfNeeded(projectID string) error {
 		return err
 	}
 
-	// Ensure ssh keys exist
-	klog.V(1).Info("Checking existing of GCP ssh keys...")
-	k := filepath.Join(home(".ssh"), "google_compute_engine")
-	if _, err := os.Stat(k); err != nil {
-		return err
-	}
-	pk := k + ".pub"
-	if _, err := os.Stat(pk); err != nil {
-		return err
+	if d.gcpSSHKeyRequired {
+		// Ensure ssh keys exist
+		klog.V(1).Info("Checking existing of GCP ssh keys...")
+		k := filepath.Join(home(".ssh"), "google_compute_engine")
+		if _, err := os.Stat(k); err != nil {
+			return err
+		}
+		pk := k + ".pub"
+		if _, err := os.Stat(pk); err != nil {
+			return err
+		}
 	}
 
 	//TODO(RonWeber): kubemark

--- a/kubetest2-gke/deployer/common.go
+++ b/kubetest2-gke/deployer/common.go
@@ -28,7 +28,8 @@ import (
 )
 
 const (
-	gkeProjectResourceType = "gke-project"
+	defaultBoskosLocation         = "http://boskos.test-pods.svc.cluster.local."
+	defaultGKEProjectResourceType = "gke-project"
 )
 
 func (d *deployer) init() error {
@@ -56,7 +57,7 @@ func (d *deployer) initialize() error {
 			for i := 0; i < d.boskosProjectsRequested; i++ {
 				resource, err := boskos.Acquire(
 					d.boskos,
-					gkeProjectResourceType,
+					d.boskosResourceType,
 					time.Duration(d.boskosAcquireTimeoutSeconds)*time.Second,
 					d.boskosHeartbeatClose,
 				)

--- a/kubetest2-gke/deployer/deployer.go
+++ b/kubetest2-gke/deployer/deployer.go
@@ -108,7 +108,11 @@ type deployer struct {
 	localLogsDir string
 	gcsLogsDir   string
 
+	// whether the GCP SSH key is required or not
+	gcpSSHKeyRequired bool
+
 	boskosLocation              string
+	boskosResourceType          string
 	boskosAcquireTimeoutSeconds int
 	// number of boskos projects to request if `projects` is empty
 	boskosProjectsRequested int
@@ -211,9 +215,11 @@ func bindFlags(d *deployer) *pflag.FlagSet {
 	flags.IntVar(&d.nodes, "num-nodes", defaultNodePool.Nodes, "For use with gcloud commands to specify the number of nodes for the cluster.")
 	flags.StringVar(&d.machineType, "machine-type", defaultNodePool.MachineType, "For use with gcloud commands to specify the machine type for the cluster.")
 	flags.StringVar(&d.stageLocation, "stage", "", "Upload binaries to gs://bucket/ci/job-suffix if set")
-	flags.StringVar(&d.boskosLocation, "boskos-location", "http://boskos.test-pods.svc.cluster.local.", "If set, manually specifies the location of the boskos server")
+	flags.BoolVar(&d.gcpSSHKeyRequired, "require-gcp-ssh-key", true, "Whether the GCP SSH key is required for bringing up the cluster.")
+	flags.StringVar(&d.boskosLocation, "boskos-location", defaultBoskosLocation, "If set, manually specifies the location of the Boskos server")
+	flags.StringVar(&d.boskosResourceType, "boskos-resource-type", defaultGKEProjectResourceType, "If set, manually specifies the resource type of GCP projects to acquire from Boskos")
 	flags.IntVar(&d.boskosAcquireTimeoutSeconds, "boskos-acquire-timeout-seconds", 300, "How long (in seconds) to hang on a request to Boskos to acquire a resource before erroring")
-	flags.IntVar(&d.boskosProjectsRequested, "projects-requested", 1, "Number of projects to request from boskos. It is only respected if projects is empty, and must be larger than zero ")
+	flags.IntVar(&d.boskosProjectsRequested, "projects-requested", 1, "Number of projects to request from Boskos. It is only respected if projects is empty, and must be larger than zero ")
 
 	return flags
 }


### PR DESCRIPTION
1. The GCP SSH key is sometimes not required, see https://github.com/knative/test-infra/blob/master/scripts/e2e-tests.sh#L232-L236. This PR adds a flag to control whether to check its existence or not.

2. Add a new flag to allow configuring the Boskos resource type for the GCP projects, rather than always using the hardcoded `gke-project`.

/cc @amwat 