### PR TITLE
Inherit output for GCE deployer build step commands

### DIFF
--- a/kubetest2-gce/deployer/build.go
+++ b/kubetest2-gce/deployer/build.go
@@ -37,6 +37,7 @@ func (d *deployer) Build() error {
 		klog.V(2).Info("starting the legacy build")
 
 		cmd := exec.Command("make", "bazel-release")
+		exec.InheritOutput(cmd)
 		cmd.SetDir(d.RepoRoot)
 		err := cmd.Run()
 		if err != nil {
@@ -47,6 +48,7 @@ func (d *deployer) Build() error {
 		klog.V(2).Info("starting the build")
 
 		cmd := exec.Command("bazel", "build", "//release:release-tars")
+		exec.InheritOutput(cmd)
 		cmd.SetDir(d.RepoRoot)
 		err := cmd.Run()
 		if err != nil {


### PR DESCRIPTION
Intended to increase transparency so a user does not think the job is hanging when in reality the build is just time-consuming.

Tested locally.