### PR TITLE
GCE deployer creates firewall rule allowing nodeport access

### DIFF
--- a/kubetest2-gce/deployer/common.go
+++ b/kubetest2-gce/deployer/common.go
@@ -128,12 +128,16 @@ func (d *deployer) buildEnv() []string {
 
 	// kube-up and kube-down get this as a default ("kubernetes") but log-dump
 	// does not. opted to set it manually here for maximum consistency
-	env = append(env, "KUBE_GCE_INSTANCE_PREFIX=kubetest2")
+	env = append(env, fmt.Sprintf("KUBE_GCE_INSTANCE_PREFIX=%s", d.instancePrefix))
 
 	// Pass through number of nodes and associated IP range. In the future,
 	// IP range will be configurable.
 	env = append(env, fmt.Sprintf("NUM_NODES=%d", d.NumNodes))
 	env = append(env, fmt.Sprintf("CLUSTER_IP_RANGE=%s", getClusterIPRange(d.NumNodes)))
+
+	// NETWORK has to be manually specified to ensure created firewall rules
+	// target the right network
+	env = append(env, fmt.Sprintf("NETWORK=%s", d.network))
 
 	if d.EnableCacheMutationDetector {
 		env = append(env, "ENABLE_CACHE_MUTATION_DETECTOR=true")

--- a/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2-gce/deployer/deployer.go
@@ -56,6 +56,12 @@ type deployer struct {
 	// so that it can be explicitly closed
 	boskosHeartbeatClose chan struct{}
 
+	// instancePrefix is set for a mandatory env and for firewall rule creation
+	// see buildEnv() and nodeTag()
+	instancePrefix string
+	// network is set for firewall rule creation, see buildEnv() and firewall.go
+	network string
+
 	BoskosAcquireTimeoutSeconds int    `desc:"How long (in seconds) to hang on a request to Boskos to acquire a resource before erroring."`
 	RepoRoot                    string `desc:"The path to the root of the local kubernetes/cloud-provider-gcp repo. Necessary to call certain scripts. Defaults to the current directory. If operating in legacy mode, this should be set to the local kubernetes/kubernetes repo."`
 	GCPProject                  string `desc:"GCP Project to create VMs in. If unset, the deployer will attempt to get a project from boskos."`
@@ -79,6 +85,8 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 		kubeconfigPath:              filepath.Join(opts.ArtifactsDir(), "kubetest2-kubeconfig"),
 		logsDir:                     filepath.Join(opts.ArtifactsDir(), "cluster-logs"),
 		boskosHeartbeatClose:        make(chan struct{}),
+		instancePrefix:              "kubetest2",
+		network:                     "default",
 		BoskosAcquireTimeoutSeconds: 5 * 60,
 		BoskosLocation:              "http://boskos.test-pods.svc.cluster.local.",
 		NumNodes:                    3,

--- a/kubetest2-gce/deployer/down.go
+++ b/kubetest2-gce/deployer/down.go
@@ -44,6 +44,11 @@ func (d *deployer) Down() error {
 		return fmt.Errorf("error encountered during %s: %s", script, err)
 	}
 
+	klog.V(2).Info("about to delete nodeport firewall rule")
+	if err := d.deleteFirewallRuleNodePort(); err != nil {
+		return fmt.Errorf("failed to delete firewall rule: %s", err)
+	}
+
 	if d.boskos != nil {
 		klog.V(2).Info("releasing boskos project")
 		err := boskos.Release(

--- a/kubetest2-gce/deployer/firewall.go
+++ b/kubetest2-gce/deployer/firewall.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/kubetest2/pkg/exec"
+)
+
+// kube-up.sh builds NODE_TAG based on KUBE_GCE_INSTANCE_PREFIX which the deployer
+// sets as d.instacePrefix. This function replicates NODE_TAG string construction
+// because it is needed for firewall rules
+func (d *deployer) nodeTag() string {
+	return fmt.Sprintf("%s-minion", d.instancePrefix)
+}
+
+func (d *deployer) nodePortRuleName() string {
+	return fmt.Sprintf("%s-nodeports", d.nodeTag())
+}
+
+func (d *deployer) createFirewallRuleNodePort() error {
+	cmd := exec.Command(
+		"gcloud", "compute", "firewall-rules", "create",
+		"--project", d.GCPProject,
+		"--target-tags", d.nodeTag(),
+		"--allow", "tcp:30000-32767,udp:30000-32767",
+		"--network", d.network,
+		d.nodePortRuleName(),
+	)
+	exec.InheritOutput(cmd)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to create nodeports firewall rule: %s", err)
+	}
+
+	return nil
+}
+
+func (d *deployer) deleteFirewallRuleNodePort() error {
+	cmd := exec.Command(
+		"gcloud", "compute", "firewall-rules", "delete",
+		"--project", d.GCPProject,
+		d.nodePortRuleName(),
+	)
+	exec.InheritOutput(cmd)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to delete nodeports firewall rules: %s", err)
+	}
+
+	return nil
+}

--- a/kubetest2-gce/deployer/up.go
+++ b/kubetest2-gce/deployer/up.go
@@ -66,6 +66,11 @@ func (d *deployer) Up() error {
 		klog.Errorf("cluster reported as down")
 	}
 
+	klog.V(2).Info("about to create nodeport firewall rule")
+	if err := d.createFirewallRuleNodePort(); err != nil {
+		return fmt.Errorf("failed to create firewall rule: %s", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This issue was overlooked for a while because testing of just the deployer works fine without these firewall rules. However, once real testing began, large groups of (unexpected) failures were noticed (see https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/92316/pull-kubernetes-e2e-gce-kubetest2/1293334635354263552), especially with the entire NodePort category of tests. Adding these firewall rules (which are present [in the old test-setup bash function](https://github.com/kubernetes/kubernetes/blob/master/cluster/gce/util.sh#L3810) this deployer replaces) resolves this issue.

Tested locally. Firewalls are correctly created and deleted. Previously failing NodePort tests pass.