### PR TITLE
Add hostport firewall rule creation to GCE deployer

### DIFF
--- a/kubetest2-gce/deployer/down.go
+++ b/kubetest2-gce/deployer/down.go
@@ -49,6 +49,11 @@ func (d *deployer) Down() error {
 		return fmt.Errorf("failed to delete firewall rule: %s", err)
 	}
 
+	klog.V(2).Info("about to delete hostport firewall rule")
+	if err := d.deleteFirewallRuleHostPort(); err != nil {
+		return fmt.Errorf("failed to delete firewall rule: %s", err)
+	}
+
 	if d.boskos != nil {
 		klog.V(2).Info("releasing boskos project")
 		err := boskos.Release(

--- a/kubetest2-gce/deployer/up.go
+++ b/kubetest2-gce/deployer/up.go
@@ -71,6 +71,11 @@ func (d *deployer) Up() error {
 		return fmt.Errorf("failed to create firewall rule: %s", err)
 	}
 
+	klog.V(2).Info("about to create hostport firewall rule")
+	if err := d.createFirewallRuleHostPort(); err != nil {
+		return fmt.Errorf("failed to create firewall rule: %s", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This additional firewall rule was experimentally determined to still be necessary despite the lingering "remove once we don't use hostport" [from the old deployer script](https://github.com/kubernetes/kubernetes/blob/master/cluster/gce/util.sh#L3791). This should allow at least `Kubectl client Kubectl logs should be able to retrieve and filter logs` to pass.

Tested locally.

Related to https://github.com/kubernetes-sigs/kubetest2/pull/34