### PR TITLE
Fix a few issues for the kubetest2-gke deployer and add chizhg as reviewer

### DIFF
--- a/kubetest2-gke/OWNERS
+++ b/kubetest2-gke/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- chizhg

--- a/kubetest2-gke/deployer/commandutils.go
+++ b/kubetest2-gke/deployer/commandutils.go
@@ -63,7 +63,7 @@ func (d *deployer) prepareGcpIfNeeded(projectID string) error {
 		return err
 	}
 
-	if d.gcpSSHKeyRequired {
+	if d.gcpSSHKeyIgnored {
 		// Ensure ssh keys exist
 		klog.V(1).Info("Checking existing of GCP ssh keys...")
 		k := filepath.Join(home(".ssh"), "google_compute_engine")


### PR DESCRIPTION
1. Print a warning message instead of returning an error for any VPC errors, since sometimes we may want to use the projects pre-configured with shared-vpc for testing, then the service account that runs this command doesn't necessarily need to have the permissions

2. Add a new `--enable-workload-identity` flag which can be used to enable workload identity for the GKE clusters

3. Add myself as the reviewer of kubetest2 gke deployer

/cc @amwat 