### PR TITLE
Add RawCommand and RawCommandContext functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module sigs.k8s.io/kubetest2
 go 1.14
 
 require (
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/octago/sflags v0.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -539,6 +539,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/kubetest2-gke/deployer/commandutils.go
+++ b/kubetest2-gke/deployer/commandutils.go
@@ -54,8 +54,8 @@ func (d *deployer) prepareGcpIfNeeded(projectID string) error {
 		return err
 	}
 
-	if err := runWithOutput(exec.Command("gcloud", "config", "set", "project", projectID)); err != nil {
-		return fmt.Errorf("Failed to set project %s : err %v", projectID, err)
+	if err := runWithOutput(exec.RawCommand("gcloud config set project " + projectID)); err != nil {
+		return fmt.Errorf("failed to set project %s : err %v", projectID, err)
 	}
 
 	// gcloud creds may have changed
@@ -85,14 +85,14 @@ func activateServiceAccount(path string) error {
 	if path == "" {
 		return nil
 	}
-	return runWithOutput(exec.Command("gcloud", "auth", "activate-service-account", "--key-file="+path))
+	return runWithOutput(exec.RawCommand("gcloud auth activate-service-account --key-file=" + path))
 }
 
 // Get the project number for the given project ID.
 func getProjectNumber(projectID string) (string, error) {
 	// Get the service project number.
-	projectNum, err := exec.Output(exec.Command("gcloud", "projects", "describe",
-		projectID, "--format=value(projectNumber)"))
+	projectNum, err := exec.Output(exec.RawCommand(
+		fmt.Sprintf("gcloud projects describe %s --format=value(projectNumber)", projectID)))
 	if err != nil {
 		return "", err
 	}

--- a/kubetest2-gke/deployer/deployer.go
+++ b/kubetest2-gke/deployer/deployer.go
@@ -289,7 +289,7 @@ func (d *deployer) Up() error {
 				args = append(args, subNetworkArgs...)
 				args = append(args, cluster)
 				klog.V(1).Infof("Gcloud command: gcloud %+v\n", args)
-				if err := runWithOutput(exec.CommandWithContext(ctx, "gcloud", args...)); err != nil {
+				if err := runWithOutput(exec.CommandContext(ctx, "gcloud", args...)); err != nil {
 					// Cancel the context to kill other cluster creation processes if any error happens.
 					cancel()
 					return fmt.Errorf("error creating cluster: %v", err)
@@ -323,7 +323,7 @@ func (d *deployer) IsUp() (up bool, err error) {
 
 			// naively assume that if the api server reports nodes, the cluster is up
 			lines, err := exec.CombinedOutputLines(
-				exec.Command("kubectl", "get", "nodes", "-o=name"),
+				exec.RawCommand("kubectl get nodes -o=name"),
 			)
 			if err != nil {
 				return false, metadata.NewJUnitError(err, strings.Join(lines, "\n"))

--- a/pkg/exec/local.go
+++ b/pkg/exec/local.go
@@ -41,8 +41,8 @@ func (c *LocalCmder) Command(name string, arg ...string) Cmd {
 	}
 }
 
-// CommandWithContext returns a new exec.Cmd with the context, backed by Cmd
-func (c *LocalCmder) CommandWithContext(ctx context.Context, name string, arg ...string) Cmd {
+// CommandContext returns a new exec.Cmd with the context, backed by Cmd
+func (c *LocalCmder) CommandContext(ctx context.Context, name string, arg ...string) Cmd {
 	return &LocalCmd{
 		Cmd: osexec.CommandContext(ctx, name, arg...),
 	}


### PR DESCRIPTION
As discussed offline, add `RawCommand` and `RawCommandContext` functions which can run more the commands in a more native way. Also use it to run some simple commands for kubetest2 gke deployer. I did some regression tests on my local and nothing breaks.

/cc @amwat 