### PR TITLE
Revert "Add hostport firewall rule creation to GCE deployer"

### DIFF
--- a/kubetest2-gce/deployer/down.go
+++ b/kubetest2-gce/deployer/down.go
@@ -49,11 +49,6 @@ func (d *deployer) Down() error {
 		return fmt.Errorf("failed to delete firewall rule: %s", err)
 	}
 
-	klog.V(2).Info("about to delete hostport firewall rule")
-	if err := d.deleteFirewallRuleHostPort(); err != nil {
-		return fmt.Errorf("failed to delete firewall rule: %s", err)
-	}
-
 	if d.boskos != nil {
 		klog.V(2).Info("releasing boskos project")
 		err := boskos.Release(

--- a/kubetest2-gce/deployer/firewall.go
+++ b/kubetest2-gce/deployer/firewall.go
@@ -33,10 +33,6 @@ func (d *deployer) nodePortRuleName() string {
 	return fmt.Sprintf("%s-nodeports", d.nodeTag())
 }
 
-func (d *deployer) hostPortRuleName() string {
-	return fmt.Sprintf("%s-http-alt", d.nodeTag())
-}
-
 func (d *deployer) createFirewallRuleNodePort() error {
 	cmd := exec.Command(
 		"gcloud", "compute", "firewall-rules", "create",
@@ -63,37 +59,6 @@ func (d *deployer) deleteFirewallRuleNodePort() error {
 	exec.InheritOutput(cmd)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to delete nodeports firewall rules: %s", err)
-	}
-
-	return nil
-}
-
-func (d *deployer) createFirewallRuleHostPort() error {
-	cmd := exec.Command(
-		"gcloud", "compute", "firewall-rules", "create",
-		"--project", d.GCPProject,
-		"--target-tags", d.nodeTag(),
-		"--allow", "tcp:80,tcp:8080",
-		"--network", d.network,
-		d.hostPortRuleName(),
-	)
-	exec.InheritOutput(cmd)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to create hostport firewall rule: %s", err)
-	}
-
-	return nil
-}
-
-func (d *deployer) deleteFirewallRuleHostPort() error {
-	cmd := exec.Command(
-		"gcloud", "compute", "firewall-rules", "delete",
-		"--project", d.GCPProject,
-		d.hostPortRuleName(),
-	)
-	exec.InheritOutput(cmd)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to delete hostport firewall rules: %s", err)
 	}
 
 	return nil

--- a/kubetest2-gce/deployer/up.go
+++ b/kubetest2-gce/deployer/up.go
@@ -71,11 +71,6 @@ func (d *deployer) Up() error {
 		return fmt.Errorf("failed to create firewall rule: %s", err)
 	}
 
-	klog.V(2).Info("about to create hostport firewall rule")
-	if err := d.createFirewallRuleHostPort(); err != nil {
-		return fmt.Errorf("failed to create firewall rule: %s", err)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Reverts kubernetes-sigs/kubetest2#35

A flaw in local testing was unveiled in CI runs. The tests that were supposed to be fixed had no changes. See https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-gce-kubetest2/1293689731040677888 for evidence.