### PR TITLE
Some fixes to kubetest2 GKE deployer

### DIFF
--- a/kubetest2-gke/deployer/up.go
+++ b/kubetest2-gke/deployer/up.go
@@ -145,14 +145,14 @@ func (d *deployer) testSetup() error {
 	if _, err := d.Kubeconfig(); err != nil {
 		return err
 	}
+	if err := d.getInstanceGroups(); err != nil {
+		return err
+	}
 
+	hostProject := d.projects[0]
 	for _, project := range d.projects {
 		for _, cluster := range d.projectClustersLayout[project] {
-			if err := d.getInstanceGroups(); err != nil {
-				return err
-			}
-
-			if err := d.ensureFirewall(project, cluster, d.network); err != nil {
+			if err := d.ensureFirewall(hostProject, project, cluster, d.network); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Fix a few subtle bugs for kubetest2 GKE deployer, mainly for firewall rules and networking for multicluster profile.

I have done the manual regression tests for both single cluster and multi-cluster, and nothing breaks.

/cc @amwat 