### PR TITLE
Add an option for overriding the release directory

### DIFF
--- a/pkg/testers/ginkgo/ginkgo.go
+++ b/pkg/testers/ginkgo/ginkgo.go
@@ -42,6 +42,7 @@ type Tester struct {
 	FocusRegex         string `desc:"Regular expression of jobs to focus on."`
 	TestPackageVersion string `desc:"The ginkgo tester uses a test package made during the kubernetes build. The tester downloads this test package from one of the release tars published to GCS. Defaults to latest. Use \"gsutil ls gs://kubernetes-release/release/\" to find release names. Example: v1.20.0-alpha.0"`
 	TestPackageBucket  string `desc:"The bucket which release tars will be downloaded from to acquire the test package. Defaults to the main kubernetes project bucket."`
+	TestPackageDir     string `desc:"The directory in the bucket which represents the type of release. Default to the release directory."`
 	TestArgs           string `desc:"Additional arguments supported by the e2e test framework (https://godoc.org/k8s.io/kubernetes/test/e2e/framework#TestContextType)."`
 
 	kubeconfigPath string
@@ -134,6 +135,7 @@ func NewDefaultTester() *Tester {
 		FlakeAttempts:     1,
 		Parallel:          1,
 		TestPackageBucket: "kubernetes-release",
+		TestPackageDir:    "release",
 	}
 }
 

--- a/pkg/testers/ginkgo/package.go
+++ b/pkg/testers/ginkgo/package.go
@@ -25,7 +25,7 @@ func (t *Tester) AcquireTestPackage() error {
 		cmd := exec.Command(
 			"gsutil",
 			"cat",
-			fmt.Sprintf("gs://%s/release/latest.txt", t.TestPackageBucket),
+			fmt.Sprintf("gs://%s/%s/latest.txt", t.TestPackageBucket, t.TestPackageDir),
 		)
 		lines, err := exec.OutputLines(cmd)
 		if err != nil {
@@ -147,8 +147,9 @@ func (t *Tester) ensureReleaseTar(downloadPath, releaseTar string) error {
 
 	cmd := exec.Command("gsutil", "cp",
 		fmt.Sprintf(
-			"gs://%s/release/%s/%s",
+			"gs://%s/%s/%s/%s",
 			t.TestPackageBucket,
+			t.TestPackageDir,
 			t.TestPackageVersion,
 			releaseTar,
 		),
@@ -164,8 +165,9 @@ func (t *Tester) ensureReleaseTar(downloadPath, releaseTar string) error {
 func (t *Tester) compareSHA(downloadPath string, releaseTar string) error {
 	cmd := exec.Command("gsutil", "cat",
 		fmt.Sprintf(
-			"gs://%s/release/%s/%s",
+			"gs://%s/%s/%s/%s",
 			t.TestPackageBucket,
+			t.TestPackageDir,
 			t.TestPackageVersion,
 			releaseTar+".sha256",
 		),


### PR DESCRIPTION
Rightnow there is a no way to use the ci builds for the testing, this PR will help to fetch ci builds from gs://kubernetes-release-dev/ci/* easily