### PR TITLE
Fix firewall rules for multiproject profile

### DIFF
--- a/kubetest2-gke/deployer/commandutils.go
+++ b/kubetest2-gke/deployer/commandutils.go
@@ -106,15 +106,10 @@ func home(parts ...string) string {
 	return filepath.Join(p...)
 }
 
-func (d *deployer) getClusterCredentials(project, cluster string) error {
+func getClusterCredentials(project, loc, cluster string) error {
 	// Get gcloud to create the file.
-	loc, err := d.location()
-	if err != nil {
-		return err
-	}
-
 	if err := runWithOutput(exec.Command("gcloud",
-		d.containerArgs("clusters", "get-credentials", cluster, "--project="+project, loc)...),
+		containerArgs("clusters", "get-credentials", cluster, "--project="+project, loc)...),
 	); err != nil {
 		return fmt.Errorf("error executing get-credentials: %v", err)
 	}

--- a/kubetest2-gke/deployer/common.go
+++ b/kubetest2-gke/deployer/common.go
@@ -113,7 +113,7 @@ func buildProjectClustersLayout(projects, clusters []string, projectClustersLayo
 	return nil
 }
 
-func (d *deployer) containerArgs(args ...string) []string {
+func containerArgs(args ...string) []string {
 	return append(append([]string{}, "container"), args...)
 }
 

--- a/kubetest2-gke/deployer/deployer.go
+++ b/kubetest2-gke/deployer/deployer.go
@@ -28,6 +28,7 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/klog"
 	"sigs.k8s.io/boskos/client"
+
 	"sigs.k8s.io/kubetest2/kubetest2-gke/deployer/options"
 	"sigs.k8s.io/kubetest2/pkg/build"
 
@@ -182,7 +183,7 @@ func (d *deployer) verifyUpFlags() error {
 	if len(d.clusters) == 0 {
 		return fmt.Errorf("--cluster-name must be set for GKE deployment")
 	}
-	if _, err := d.location(); err != nil {
+	if err := d.verifyLocationFlags(); err != nil {
 		return err
 	}
 	if d.nodes <= 0 {
@@ -218,23 +219,27 @@ func (d *deployer) verifyDownFlags() error {
 	if len(d.projects) == 0 {
 		return fmt.Errorf("--project must be set for GKE deployment")
 	}
-	if _, err := d.location(); err != nil {
+	if err := d.verifyLocationFlags(); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (d *deployer) location() (string, error) {
+func (d *deployer) verifyLocationFlags() error {
 	if d.zone == "" && d.region == "" {
-		return "", fmt.Errorf("--zone or --region must be set for GKE deployment")
+		return fmt.Errorf("--zone or --region must be set for GKE deployment")
 	} else if d.zone != "" && d.region != "" {
-		return "", fmt.Errorf("--zone and --region cannot both be set")
+		return fmt.Errorf("--zone and --region cannot both be set")
 	}
+	return nil
+}
 
-	if d.zone != "" {
-		return "--zone=" + d.zone, nil
+// location returns the location flags for gcloud commands.
+func location(region, zone string) string {
+	if zone != "" {
+		return "--zone=" + zone
 	}
-	return "--region=" + d.region, nil
+	return "--region=" + region
 }
 
 func bindFlags(d *deployer) *pflag.FlagSet {

--- a/kubetest2-gke/deployer/down.go
+++ b/kubetest2-gke/deployer/down.go
@@ -38,17 +38,14 @@ func (d *deployer) Down() error {
 			project := d.projects[i]
 			for j := range d.projectClustersLayout[project] {
 				cluster := d.projectClustersLayout[project][j]
-				loc, err := d.location()
-				if err != nil {
-					return err
-				}
+				loc := location(d.region, d.zone)
 
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
 					// We best-effort try all of these and report errors as appropriate.
 					if err := runWithOutput(exec.Command(
-						"gcloud", d.containerArgs("clusters", "delete", "-q", cluster,
+						"gcloud", containerArgs("clusters", "delete", "-q", cluster,
 							"--project="+project,
 							loc)...)); err != nil {
 						klog.Errorf("Error deleting cluster: %v", err)


### PR DESCRIPTION
This PR does the following:

1. Follow https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc#creating_firewall_rules to create the firewall rules for shared VPC. Still use the default `e2eAllow` firewall rules for single project.

2. Clean up the code the bit to remove `deployer` as the receiver for some simple functions.

3. Make the hack sleep a bit longer for the `cleanupNetworkFirewalls` function. Since normally we do not use `--down` in CI as we use `boskos-janitor` for cleanups, this change should only impact local runs.

--- 

I have tested the changes for multi-project multi-cluster, single project multi-cluster and single cluster, and nothing breaks (I'll submit a PR to add e2e presubmit tests for gke deployer soon).

/cc @amwat 