### PR TITLE
Add a unique identifier to kubetest2 runs

### DIFF
--- a/kubetest2-gke/deployer/build.go
+++ b/kubetest2-gke/deployer/build.go
@@ -19,8 +19,6 @@ package deployer
 import (
 	"fmt"
 	"strings"
-
-	"github.com/google/uuid"
 )
 
 func (d *deployer) Build() error {
@@ -32,7 +30,7 @@ func (d *deployer) Build() error {
 		return err
 	}
 	version = strings.TrimPrefix(version, "v")
-	version += ".0+" + uuid.New().String()
+	version += ".0+" + d.commonOptions.UUID()
 	if d.BuildOptions.StageLocation != "" {
 		if err := d.BuildOptions.Stage(version); err != nil {
 			return fmt.Errorf("error staging build: %v", err)

--- a/kubetest2-gke/deployer/build.go
+++ b/kubetest2-gke/deployer/build.go
@@ -30,7 +30,7 @@ func (d *deployer) Build() error {
 		return err
 	}
 	version = strings.TrimPrefix(version, "v")
-	version += ".0+" + d.commonOptions.UUID()
+	version += ".0+" + d.commonOptions.RunID()
 	if d.BuildOptions.StageLocation != "" {
 		if err := d.BuildOptions.Stage(version); err != nil {
 			return fmt.Errorf("error staging build: %v", err)

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -22,8 +22,9 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
-	"sigs.k8s.io/kubetest2/pkg/exec"
+	"k8s.io/klog"
 
+	"sigs.k8s.io/kubetest2/pkg/exec"
 	"sigs.k8s.io/kubetest2/pkg/metadata"
 	"sigs.k8s.io/kubetest2/pkg/types"
 )
@@ -83,6 +84,8 @@ func RealMain(opts types.Options, d types.Deployer, tester types.Tester) (result
 		}
 	}()
 
+	klog.Infof("UUID for this run: %q", opts.UUID())
+
 	// build if specified
 	if opts.ShouldBuild() {
 		if err := writer.WrapStep("Build", d.Build); err != nil {
@@ -118,6 +121,7 @@ func RealMain(opts types.Options, d types.Deployer, tester types.Tester) (result
 
 		envsForTester := os.Environ()
 		envsForTester = append(envsForTester, fmt.Sprintf("%s=%s", "ARTIFACTS", opts.ArtifactsDir()))
+		envsForTester = append(envsForTester, fmt.Sprintf("%s=%s", "KUBETEST2_UUID", opts.UUID()))
 		// If the deployer provides a kubeconfig pass it to the tester
 		// else assumes that it is handled offline by default methods like
 		// ~/.kube/config

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -84,7 +84,7 @@ func RealMain(opts types.Options, d types.Deployer, tester types.Tester) (result
 		}
 	}()
 
-	klog.Infof("UUID for this run: %q", opts.UUID())
+	klog.Infof("ID for this run: %q", opts.RunID())
 
 	// build if specified
 	if opts.ShouldBuild() {
@@ -121,7 +121,7 @@ func RealMain(opts types.Options, d types.Deployer, tester types.Tester) (result
 
 		envsForTester := os.Environ()
 		envsForTester = append(envsForTester, fmt.Sprintf("%s=%s", "ARTIFACTS", opts.ArtifactsDir()))
-		envsForTester = append(envsForTester, fmt.Sprintf("%s=%s", "KUBETEST2_UUID", opts.UUID()))
+		envsForTester = append(envsForTester, fmt.Sprintf("%s=%s", "KUBETEST2_RUN_ID", opts.RunID()))
 		// If the deployer provides a kubeconfig pass it to the tester
 		// else assumes that it is handled offline by default methods like
 		// ~/.kube/config

--- a/pkg/app/cmd.go
+++ b/pkg/app/cmd.go
@@ -161,7 +161,7 @@ func runE(
 		return parseError
 	}
 
-	opts.artifacts = filepath.Join(opts.artifacts, opts.uuid)
+	opts.artifacts = filepath.Join(opts.artifacts, opts.runid)
 
 	// run RealMain, which contains all of the logic beyond the CLI boilerplate
 	return RealMain(opts, deployer, tester)
@@ -210,7 +210,7 @@ type options struct {
 	down      bool
 	test      string
 	artifacts string
-	uuid      string
+	runid     string
 }
 
 // bindFlags registers all first class kubetest2 flags
@@ -221,14 +221,14 @@ func (o *options) bindFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&o.down, "down", false, "tear down the test cluster")
 	flags.StringVar(&o.test, "test", "", "test type to run, if unset no tests will run")
 
-	var defaultUUID string
-	// reuse uuid for CI use cases
+	var defaultRunID string
+	// reuse uid for CI use cases
 	if uid, exists := os.LookupEnv("PROW_JOB_ID"); exists && uid != "" {
-		defaultUUID = uid
+		defaultRunID = uid
 	} else {
-		defaultUUID = uuid.New().String()
+		defaultRunID = uuid.New().String()
 	}
-	flags.StringVar(&o.uuid, "uuid", defaultUUID, "unique identifier for a kubetest2 run")
+	flags.StringVar(&o.runid, "run-id", defaultRunID, "unique identifier for a kubetest2 run")
 
 	defaultArtifacts, err := defaultArtifactsDir()
 	if err != nil {
@@ -264,8 +264,8 @@ func (o *options) ArtifactsDir() string {
 	return o.artifacts
 }
 
-func (o *options) UUID() string {
-	return o.uuid
+func (o *options) RunID() string {
+	return o.runid
 }
 
 // metadata used for CLI usage string

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -57,8 +57,8 @@ type Options interface {
 	// returns the path to the directory where artifacts should be written
 	// (including metadata files like junit_runner.xml)
 	ArtifactsDir() string
-	// UUID returns a unique identifier for a kubetest2 run.
-	UUID() string
+	// RunID returns a unique identifier for a kubetest2 run.
+	RunID() string
 }
 
 // Deployer defines the interface between kubetest and a deployer

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -57,6 +57,8 @@ type Options interface {
 	// returns the path to the directory where artifacts should be written
 	// (including metadata files like junit_runner.xml)
 	ArtifactsDir() string
+	// UUID returns a unique identifier for a kubetest2 run.
+	UUID() string
 }
 
 // Deployer defines the interface between kubetest and a deployer


### PR DESCRIPTION
Provides a way for deployers and tester to store relevant artifacts for potential re-use.
Also, simplifies artifacts storage for different runs in local use cases.