### PR TITLE
Add --release-channel flag for kubetest2 gke deployer

### DIFF
--- a/kubetest2-gke/deployer/deployer.go
+++ b/kubetest2-gke/deployer/deployer.go
@@ -85,8 +85,9 @@ type deployer struct {
 
 	BuildOptions *options.BuildOptions
 
-	RepoRoot string `desc:"Path to root of the kubernetes repo. Used with --build and for dumping cluster logs."`
-	Version  string `desc:"Use a specific GKE version e.g. 1.16.13.gke-400 or 'latest'. If --build is specified it will default to building kubernetes from source."`
+	RepoRoot       string `desc:"Path to root of the kubernetes repo. Used with --build and for dumping cluster logs."`
+	ReleaseChannel string `desc:"Use a GKE release channel, could be one of empty, rapid, regular and stable - https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels"`
+	Version        string `desc:"Use a specific GKE version e.g. 1.16.13.gke-400 or 'latest'. If --build is specified it will default to building kubernetes from source."`
 
 	// doInit helps to make sure the initialization is performed only once
 	doInit sync.Once

--- a/kubetest2-gke/deployer/up.go
+++ b/kubetest2-gke/deployer/up.go
@@ -81,10 +81,18 @@ func (d *deployer) Up() error {
 					"--image-type="+image,
 					"--num-nodes="+strconv.Itoa(d.nodes),
 					"--network="+transformNetworkName(d.projects, d.network),
-					"--cluster-version="+d.Version,
 				)
 				if d.workloadIdentityEnabled {
 					args = append(args, fmt.Sprintf("--workload-pool=%s.svc.id.goog", project))
+				}
+				if d.ReleaseChannel != "" {
+					args = append(args, "--release-channel="+d.ReleaseChannel)
+					// --cluster-version must be a specific valid version if --release-channel is not empty.
+					if d.Version != "latest" {
+						args = append(args, "--cluster-version="+d.Version)
+					}
+				} else {
+					args = append(args, "--cluster-version="+d.Version)
 				}
 				args = append(args, subNetworkArgs...)
 				args = append(args, privateClusterArgs...)


### PR DESCRIPTION
Since `--release-channel` is usually paired with `--cluster-version` flag, and there is a constraint for using them together - `--cluster-version` must be a valid version if used together with `--release-channel`, add `--release-channel` flag and perform necessary validations in constructing the `gcloud` command.

/cc @amwat 