### PR TITLE
[GKE] Add functionality to auto-generate cluster names

### DIFF
--- a/kubetest2-gke/deployer/down.go
+++ b/kubetest2-gke/deployer/down.go
@@ -17,6 +17,7 @@ limitations under the License.
 package deployer
 
 import (
+	"fmt"
 	"sync"
 
 	"k8s.io/klog"
@@ -68,6 +69,20 @@ func (d *deployer) Down() error {
 		if err := d.deleteNetwork(); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// verifyDownFlags validates flags for down phase.
+func (d *deployer) verifyDownFlags() error {
+	if len(d.clusters) == 0 {
+		return fmt.Errorf("--cluster-name must be set for GKE deployment")
+	}
+	if len(d.projects) == 0 {
+		return fmt.Errorf("--project must be set for GKE deployment")
+	}
+	if err := d.verifyLocationFlags(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/kubetest2-gke/deployer/options/up.go
+++ b/kubetest2-gke/deployer/options/up.go
@@ -1,0 +1,15 @@
+package options
+
+import "fmt"
+
+type UpOptions struct {
+	NumClusters int `flag:"~num-clusters" desc:"Number of clusters to create, will auto-generate names as (kt2-<run-id>-<index>)"`
+}
+
+func (uo *UpOptions) Validate() error {
+	// allow max 99 clusters (should be sufficient for most use cases)
+	if uo.NumClusters < 1 || uo.NumClusters > 99 {
+		return fmt.Errorf("need to specify between 1 and 99 clusters got %q: ", uo.NumClusters)
+	}
+	return nil
+}

--- a/kubetest2-gke/deployer/up.go
+++ b/kubetest2-gke/deployer/up.go
@@ -242,7 +242,7 @@ func generateClusterNames(numClusters int, uid string) []string {
 		// Naming convention: https://cloud.google.com/sdk/gcloud/reference/container/clusters/create#POSITIONAL-ARGUMENTS
 		// must start with an alphabet, max length 40
 
-		// 4 characters for kt2- prefix
+		// 4 characters for kt2- prefix (short for kubetest2)
 		const fixedClusterNamePrefix = "kt2-"
 		// 3 characters -99 suffix
 		clusterNameSuffix := strconv.Itoa(i)

--- a/kubetest2-gke/deployer/up_test.go
+++ b/kubetest2-gke/deployer/up_test.go
@@ -1,0 +1,78 @@
+package deployer
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGenerateClusterNames(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		numClusters          int
+		uid                  string
+		expectedClusterNames []string
+	}{
+		{
+			name:                 "zero clusters",
+			uid:                  "foobar",
+			expectedClusterNames: []string{},
+		},
+		{
+			name:        "empty uid",
+			numClusters: 3,
+			expectedClusterNames: []string{
+				"kt2-1",
+				"kt2-2",
+				"kt2-3",
+			},
+		},
+		{
+			name:        "3 clusters, 6 character uid",
+			numClusters: 3,
+			uid:         "foobar",
+			expectedClusterNames: []string{
+				"kt2-foobar-1",
+				"kt2-foobar-2",
+				"kt2-foobar-3",
+			},
+		},
+		{
+			name:        "20 clusters, 36 character uid",
+			numClusters: 20,
+			uid:         "abcdefghijklmnopqrstuvwxyz0123456789",
+			expectedClusterNames: []string{
+				"kt2-abcdefghijklmnopqrstuvwxyz0123456-1",
+				"kt2-abcdefghijklmnopqrstuvwxyz0123456-2",
+				"kt2-abcdefghijklmnopqrstuvwxyz0123456-3",
+				"kt2-abcdefghijklmnopqrstuvwxyz0123456-4",
+				"kt2-abcdefghijklmnopqrstuvwxyz0123456-5",
+				"kt2-abcdefghijklmnopqrstuvwxyz0123456-6",
+				"kt2-abcdefghijklmnopqrstuvwxyz0123456-7",
+				"kt2-abcdefghijklmnopqrstuvwxyz0123456-8",
+				"kt2-abcdefghijklmnopqrstuvwxyz0123456-9",
+				"kt2-abcdefghijklmnopqrstuvwxyz0123456-10",
+				"kt2-abcdefghijklmnopqrstuvwxyz0123456-11",
+				"kt2-abcdefghijklmnopqrstuvwxyz0123456-12",
+				"kt2-abcdefghijklmnopqrstuvwxyz0123456-13",
+				"kt2-abcdefghijklmnopqrstuvwxyz0123456-14",
+				"kt2-abcdefghijklmnopqrstuvwxyz0123456-15",
+				"kt2-abcdefghijklmnopqrstuvwxyz0123456-16",
+				"kt2-abcdefghijklmnopqrstuvwxyz0123456-17",
+				"kt2-abcdefghijklmnopqrstuvwxyz0123456-18",
+				"kt2-abcdefghijklmnopqrstuvwxyz0123456-19",
+				"kt2-abcdefghijklmnopqrstuvwxyz0123456-20",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			actualClusterNames := generateClusterNames(tc.numClusters, tc.uid)
+			if !reflect.DeepEqual(actualClusterNames, tc.expectedClusterNames) {
+				t.Errorf("expected cluster names to be: %v\nbut got %v", tc.expectedClusterNames, actualClusterNames)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is especially useful in multi-cluster use cases where specifying cluster names explicitly is tedious and unnecessary.
Multi-project use cases will still need to set the names explicitly.
