### PR TITLE
Allow specifying the latest version for a release channel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/klog v1.0.0
 	sigs.k8s.io/boskos v0.0.0-20200710214748-f5935686c7fc
 )

--- a/kubetest2-gke/deployer/commandutils.go
+++ b/kubetest2-gke/deployer/commandutils.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"gopkg.in/yaml.v2"
 	"k8s.io/klog"
 
 	"sigs.k8s.io/kubetest2/pkg/exec"
@@ -115,4 +116,37 @@ func getClusterCredentials(project, loc, cluster string) error {
 	}
 
 	return nil
+}
+
+// Resolve the current latest version in the given release channel.
+func resolveLatestVersionInChannel(loc, channelName string) (string, error) {
+	// Get the server config for the current location.
+	out, err := exec.Output(exec.RawCommand(
+		fmt.Sprintf("gcloud container get-server-config --format=\"yaml(channels:format='yaml(channel,validVersions)')\" %s", loc)))
+	if err != nil {
+		return "", fmt.Errorf("failed to get the server config: %w", err)
+	}
+
+	type Channel struct {
+		Name          string   `yaml:"channel"`
+		ValidVersions []string `yaml:"validVersions"`
+	}
+	type Channels struct {
+		Channels []Channel `yaml:"channels"`
+	}
+	var cs Channels
+	if err = yaml.Unmarshal(out, &cs); err != nil {
+		return "", fmt.Errorf("failed to unmarshal the server config: %w", err)
+	}
+
+	for _, channel := range cs.Channels {
+		if strings.EqualFold(channel.Name, channelName) {
+			if len(channel.ValidVersions) == 0 {
+				return "", fmt.Errorf("no valid versions for channel %q", channelName)
+			}
+			return channel.ValidVersions[0], nil
+		}
+	}
+
+	return "", fmt.Errorf("channel %q does not exist in the server config", channelName)
 }

--- a/kubetest2-gke/deployer/deployer.go
+++ b/kubetest2-gke/deployer/deployer.go
@@ -88,7 +88,7 @@ type deployer struct {
 
 	RepoRoot       string `desc:"Path to root of the kubernetes repo. Used with --build and for dumping cluster logs."`
 	ReleaseChannel string `desc:"Use a GKE release channel, could be one of empty, rapid, regular and stable - https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels"`
-	Version        string `desc:"Use a specific GKE version e.g. 1.16.13.gke-400 or 'latest'. If --build is specified it will default to building kubernetes from source."`
+	Version        string `desc:"Use a specific GKE version e.g. 1.16.13.gke-400, 'latest' or ''. If --build is specified it will default to building kubernetes from source."`
 
 	// doInit helps to make sure the initialization is performed only once
 	doInit sync.Once
@@ -166,7 +166,8 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 			NumClusters: 1,
 		},
 		localLogsDir: filepath.Join(opts.ArtifactsDir(), "logs"),
-		Version:      "latest",
+		// Leave Version as empty to use the default cluster version.
+		Version: "",
 	}
 
 	// register flags


### PR DESCRIPTION
When we run `gcloud` command with `--release-channel=xxx --cluster-version=latest`, it will give an error like `ERROR: (gcloud.container.clusters.create) ResponseError: code=400, message=Master version must be one of "REGULAR" channel supported versions [1.16.13-gke.401, 1.17.9-gke.1504].`.

This PR allows users to specify `latest` as the cluster version when `--release-channel` is not empty by resolving the actual latest version from the server config.

Also allow specifying an empty string as the cluster version, in which case the default cluster version will be used.