### PR TITLE
Add helper for using exec.CommandContext

### DIFF
--- a/pkg/process/junitexec.go
+++ b/pkg/process/junitexec.go
@@ -18,6 +18,7 @@ package process
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"os"
 	"os/exec"
@@ -41,6 +42,15 @@ var _ metadata.JUnitError = &execJunitError{}
 func ExecJUnit(argv0 string, args []string, env []string) error {
 	// construct command from inputs
 	cmd := exec.Command(argv0, args...)
+	return execJUnit(cmd, env)
+}
+
+func ExecJUnitContext(ctx context.Context, argv0 string, args []string, env []string) error {
+	cmd := exec.CommandContext(ctx, argv0, args...)
+	return execJUnit(cmd, env)
+}
+
+func execJUnit(cmd *exec.Cmd, env []string) error {
 	cmd.Env = env
 
 	// inherit some standard file descriptors, as if `syscall.Exec`ed


### PR DESCRIPTION
Really excited about this project! I am spiking on a CAPI provider (https://github.com/benmoss/kubetest2/tree/capi-deployer, though I think it might end up living in the core CAPI repo) and one of the things I needed was a version of the `ExecJUNit` process runner that takes a context.Context argument for doing command timeouts.

Thought it should live in this repo, since others probably can take advantage of it too.