### PR TITLE
Fix --private-cluster-master-ip-range arg for multicluster

### DIFF
--- a/kubetest2-gke/deployer/commandutils.go
+++ b/kubetest2-gke/deployer/commandutils.go
@@ -56,7 +56,7 @@ func (d *deployer) prepareGcpIfNeeded(projectID string) error {
 	}
 
 	if err := runWithOutput(exec.RawCommand("gcloud config set project " + projectID)); err != nil {
-		return fmt.Errorf("failed to set project %s : err %v", projectID, err)
+		return fmt.Errorf("failed to set project %s: %w", projectID, err)
 	}
 
 	// gcloud creds may have changed

--- a/kubetest2-gke/deployer/deployer.go
+++ b/kubetest2-gke/deployer/deployer.go
@@ -79,6 +79,12 @@ type ig struct {
 	uniq string
 }
 
+type cluster struct {
+	// index is the index of the cluster in the list provided via the --cluster-name flag
+	index int
+	name  string
+}
+
 type deployer struct {
 	// generic parts
 	commonOptions types.Options
@@ -98,7 +104,7 @@ type deployer struct {
 	region   string
 	clusters []string
 	// only used for multi-project multi-cluster profile to save the project-clusters mapping
-	projectClustersLayout map[string][]string
+	projectClustersLayout map[string][]cluster
 	nodes                 int
 	machineType           string
 	network               string
@@ -124,8 +130,8 @@ type deployer struct {
 
 	// Private cluster access level, must be one of "no", "limited" and "unrestricted".
 	// See the details in https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters
-	privateClusterAccessLevel   string
-	privateClusterMasterIPRange string
+	privateClusterAccessLevel    string
+	privateClusterMasterIPRanges []string
 
 	boskosLocation              string
 	boskosResourceType          string
@@ -219,7 +225,7 @@ func bindFlags(d *deployer) *pflag.FlagSet {
 	flags.BoolVar(&d.gcpSSHKeyIgnored, "ignore-gcp-ssh-key", false, "Whether the GCP SSH key should be ignored or not for bringing up the cluster.")
 	flags.BoolVar(&d.workloadIdentityEnabled, "enable-workload-identity", false, "Whether enable workload identity for the cluster or not.")
 	flags.StringVar(&d.privateClusterAccessLevel, "private-cluster-access-level", "", "Private cluster access level, if not empty, must be one of 'no', 'limited' or 'unrestricted'")
-	flags.StringVar(&d.privateClusterMasterIPRange, "private-cluster-master-ip-range", "172.16.0.32/28", "Private cluster master IP range. It should be an IPv4 CIDR, and must not be empty if private cluster is requested.")
+	flags.StringSliceVar(&d.privateClusterMasterIPRanges, "private-cluster-master-ip-range", []string{"172.16.0.32/28"}, "Private cluster master IP ranges. It should be IPv4 CIDR(s), and its length must be the same as the number of clusters if private cluster is requested.")
 	flags.StringVar(&d.boskosLocation, "boskos-location", defaultBoskosLocation, "If set, manually specifies the location of the Boskos server")
 	flags.StringVar(&d.boskosResourceType, "boskos-resource-type", defaultGKEProjectResourceType, "If set, manually specifies the resource type of GCP projects to acquire from Boskos")
 	flags.IntVar(&d.boskosAcquireTimeoutSeconds, "boskos-acquire-timeout-seconds", 300, "How long (in seconds) to hang on a request to Boskos to acquire a resource before erroring")

--- a/kubetest2-gke/deployer/down.go
+++ b/kubetest2-gke/deployer/down.go
@@ -46,7 +46,7 @@ func (d *deployer) Down() error {
 					defer wg.Done()
 					// We best-effort try all of these and report errors as appropriate.
 					if err := runWithOutput(exec.Command(
-						"gcloud", containerArgs("clusters", "delete", "-q", cluster,
+						"gcloud", containerArgs("clusters", "delete", "-q", cluster.name,
 							"--project="+project,
 							loc)...)); err != nil {
 						klog.Errorf("Error deleting cluster: %v", err)

--- a/kubetest2-gke/deployer/dumplogs.go
+++ b/kubetest2-gke/deployer/dumplogs.go
@@ -66,7 +66,7 @@ export KUBE_NODE_OS_DISTRIBUTION='%[3]s'
 			if err := d.getInstanceGroups(); err != nil {
 				return err
 			}
-			for _, ig := range d.instanceGroups[project][cluster] {
+			for _, ig := range d.instanceGroups[project][cluster.name] {
 				filters = append(filters, fmt.Sprintf("(metadata.created-by:*%s)", ig.path))
 			}
 		}

--- a/kubetest2-gke/deployer/network.go
+++ b/kubetest2-gke/deployer/network.go
@@ -38,7 +38,16 @@ etag: %s
 `
 
 func (d *deployer) verifyNetworkFlags() error {
-	// For single project, no verification is needed.
+	// Verify private cluster args.
+	if d.privateClusterAccessLevel != "" && d.privateClusterAccessLevel != string(no) &&
+		d.privateClusterAccessLevel != string(limited) && d.privateClusterAccessLevel != string(unrestricted) {
+		return fmt.Errorf("--private-cluster-access-level must be one of %v", []string{"", string(no), string(limited), string(unrestricted)})
+	}
+	if d.privateClusterAccessLevel != "" && len(d.clusters) != len(d.privateClusterMasterIPRanges) {
+		return fmt.Errorf("--private-cluster-master-ip-range must have the same length as the number of clusters when requesting private cluster(s)")
+	}
+
+	// For single project, no other verification is needed.
 	numProjects := len(d.projects)
 	if numProjects == 0 {
 		numProjects = d.boskosProjectsRequested
@@ -62,14 +71,6 @@ func (d *deployer) verifyNetworkFlags() error {
 			return fmt.Errorf("the provided subnetwork range %s is not in the right format, should be like "+
 				"10.0.4.0/22 10.0.32.0/20 10.4.0.0/14", sr)
 		}
-	}
-
-	if d.privateClusterAccessLevel != "" && d.privateClusterAccessLevel != string(no) &&
-		d.privateClusterAccessLevel != string(limited) && d.privateClusterAccessLevel != string(unrestricted) {
-		return fmt.Errorf("--private-cluster-access-level must be one of %v", []string{"", string(no), string(limited), string(unrestricted)})
-	}
-	if d.privateClusterAccessLevel != "" && d.privateClusterMasterIPRange == "" {
-		return fmt.Errorf("--private-cluster-master-ip-range must not be empty when requesting a private cluster")
 	}
 
 	return nil


### PR DESCRIPTION
Fix `--private-cluster-master-ip-range` arg for multicluster: 

when we create multiple private clusters, we need to specify different `master-ip-range` for each cluster, otherwise there will be conflict. This PR allows the `--private-cluster-master-ip-range` arg to be accepting an array, and the length of it must be the same as the number of clusters.