### PR TITLE
Fix an 'index out of range' error when creating non-private clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module sigs.k8s.io/kubetest2
 go 1.14
 
 require (
+	github.com/google/go-cmp v0.5.2
 	github.com/google/uuid v1.1.2
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/octago/sflags v0.2.0

--- a/kubetest2-gke/deployer/network.go
+++ b/kubetest2-gke/deployer/network.go
@@ -362,18 +362,18 @@ func removeHostServiceAgentUserRole(projects []string) error {
 
 // This function returns the args required for creating a private cluster.
 // Reference: https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#top_of_page
-func privateClusterArgs(network, cluster, accessLevel, masterIPRange string) []string {
+func privateClusterArgs(network, accessLevel string, masterIPRanges []string, clusterInfo cluster) []string {
 	if accessLevel == "" {
 		return []string{}
 	}
 
-	subnetName := network + "-" + cluster
+	subnetName := network + "-" + clusterInfo.name
 	common := []string{
 		"--create-subnetwork=name=" + subnetName,
 		"--enable-ip-alias",
 		"--enable-private-nodes",
 		"--no-enable-basic-auth",
-		"--master-ipv4-cidr=" + masterIPRange,
+		"--master-ipv4-cidr=" + masterIPRanges[clusterInfo.index],
 		"--no-issue-client-certificate",
 	}
 

--- a/kubetest2-gke/deployer/network_test.go
+++ b/kubetest2-gke/deployer/network_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestPrivateClusterArgs(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		network        string
+		accessLevel    string
+		masterIPRanges []string
+		clusterInfo    cluster
+		expected       []string
+	}{
+		{
+			desc:           "no private cluster args are needed for non-private clusters",
+			network:        "whatever-network",
+			accessLevel:    "",
+			masterIPRanges: []string{"whatever-master-IP-range"},
+			clusterInfo:    cluster{index: 0, name: "whatever-cluster-name"},
+			expected:       []string{},
+		},
+		{
+			desc:           "test private cluster args for private cluster with no limit",
+			network:        "test-network1",
+			accessLevel:    string(no),
+			masterIPRanges: []string{"172.16.0.32/28"},
+			clusterInfo:    cluster{index: 0, name: "cluster1"},
+			expected: []string{
+				"--create-subnetwork=name=test-network1-cluster1",
+				"--enable-ip-alias",
+				"--enable-private-nodes",
+				"--no-enable-basic-auth",
+				"--master-ipv4-cidr=172.16.0.32/28",
+				"--no-issue-client-certificate",
+				"--enable-master-authorized-networks",
+				"--enable-private-endpoint",
+			},
+		},
+		{
+			desc:           "test private cluster args for private cluster with limited network access",
+			network:        "test-network2",
+			accessLevel:    string(limited),
+			masterIPRanges: []string{"173.16.0.32/28"},
+			clusterInfo:    cluster{index: 0, name: "cluster2"},
+			expected: []string{
+				"--create-subnetwork=name=test-network2-cluster2",
+				"--enable-ip-alias",
+				"--enable-private-nodes",
+				"--no-enable-basic-auth",
+				"--master-ipv4-cidr=173.16.0.32/28",
+				"--no-issue-client-certificate",
+				"--enable-master-authorized-networks",
+			},
+		},
+		{
+			desc:           "test private cluster args for private cluster with unrestricted network access",
+			network:        "test-network3",
+			accessLevel:    string(unrestricted),
+			masterIPRanges: []string{"173.16.0.32/28", "175.16.0.32/22"},
+			clusterInfo:    cluster{index: 1, name: "cluster3"},
+			expected: []string{
+				"--create-subnetwork=name=test-network3-cluster3",
+				"--enable-ip-alias",
+				"--enable-private-nodes",
+				"--no-enable-basic-auth",
+				"--master-ipv4-cidr=175.16.0.32/22",
+				"--no-issue-client-certificate",
+				"--no-enable-master-authorized-networks",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(st *testing.T) {
+			st.Parallel()
+			actual := privateClusterArgs(tc.network, tc.accessLevel, tc.masterIPRanges, tc.clusterInfo)
+			if diff := cmp.Diff(actual, tc.expected); diff != "" {
+				st.Error("Got private cluster args (-want, +got) =", diff)
+			}
+		})
+	}
+}

--- a/kubetest2-gke/deployer/network_test.go
+++ b/kubetest2-gke/deployer/network_test.go
@@ -40,6 +40,14 @@ func TestPrivateClusterArgs(t *testing.T) {
 			expected:       []string{},
 		},
 		{
+			desc:           "--private-cluster-master-ip-range can be empty for non-private clusters",
+			network:        "whatever-network",
+			accessLevel:    "",
+			masterIPRanges: []string{},
+			clusterInfo:    cluster{index: 0, name: "whatever-cluster-name"},
+			expected:       []string{},
+		},
+		{
 			desc:           "test private cluster args for private cluster with no limit",
 			network:        "test-network1",
 			accessLevel:    string(no),

--- a/kubetest2-gke/deployer/up.go
+++ b/kubetest2-gke/deployer/up.go
@@ -70,7 +70,7 @@ func (d *deployer) Up() error {
 		subNetworkArgs := subNetworkArgs(d.projects, d.region, d.network, i)
 		for j := range d.projectClustersLayout[project] {
 			cluster := d.projectClustersLayout[project][j]
-			privateClusterArgs := privateClusterArgs(d.network, cluster.name, d.privateClusterAccessLevel, d.privateClusterMasterIPRanges[cluster.index])
+			privateClusterArgs := privateClusterArgs(d.network, d.privateClusterAccessLevel, d.privateClusterMasterIPRanges, cluster)
 			eg.Go(func() error {
 				// Create the cluster
 				args := make([]string, len(d.createCommand()))


### PR DESCRIPTION
When creating multiple non-private clusters, the length of `privateClusterMasterIPRanges` will be default to 1, but the cluster index can be larger than 0, thus causing an 'index out of range' error.

This PR fixes the bug.

/cc @amwat 