### PR TITLE
Use Project Number instead of ID for firewall name

### DIFF
--- a/kubetest2-gke/deployer/firewall.go
+++ b/kubetest2-gke/deployer/firewall.go
@@ -94,13 +94,13 @@ func ensureFirewallRulesForMultiProjects(projects []string, network string, subn
 	hostProject := projects[0]
 	hostProjectNumber, err := getProjectNumber(hostProject)
 	if err != nil {
-		return fmt.Errorf("error looking up project number for id %v. Original error: %v", hostProject, err)
+		return fmt.Errorf("error looking up project number for id %q: %w", hostProject, err)
 	}
 	for i := 1; i < len(projects); i++ {
 		curtProject := projects[i]
 		curtProjectNumber, err := getProjectNumber(curtProject)
 		if err != nil {
-			return fmt.Errorf("error looking up project number for id %v. Original error: %v", curtProject, err)
+			return fmt.Errorf("error looking up project number for id %q: %w", curtProject, err)
 		}
 		firewall := fmt.Sprintf("rule-%s-%s", hostProjectNumber, curtProjectNumber)
 		// sourceRanges need to be separated with ",", while the provided subnetworkRanges are separated with space.

--- a/kubetest2-gke/deployer/firewall.go
+++ b/kubetest2-gke/deployer/firewall.go
@@ -92,9 +92,17 @@ func getClusterFirewall(project, cluster string, instanceGroups map[string]map[s
 // Please note we are not including the firewall rule for SSH connection as it's not needed for testing.
 func ensureFirewallRulesForMultiProjects(projects []string, network string, subnetworkRanges []string) error {
 	hostProject := projects[0]
+	hostProjectNumber, err := getProjectNumber(hostProject)
+	if err != nil {
+		return fmt.Errorf("error looking up project number for id %v. Original error: %v", hostProject, err)
+	}
 	for i := 1; i < len(projects); i++ {
 		curtProject := projects[i]
-		firewall := fmt.Sprintf("%s-rule-%s", hostProject, curtProject)
+		curtProjectNumber, err := getProjectNumber(curtProject)
+		if err != nil {
+			return fmt.Errorf("error looking up project number for id %v. Original error: %v", curtProject, err)
+		}
+		firewall := fmt.Sprintf("rule-%s-%s", hostProjectNumber, curtProjectNumber)
 		// sourceRanges need to be separated with ",", while the provided subnetworkRanges are separated with space.
 		sourceRanges := strings.ReplaceAll(subnetworkRanges[i-1], " ", ",")
 		if err := runWithOutput(exec.Command("gcloud", "compute", "firewall-rules", "create", firewall,


### PR DESCRIPTION
See b/175617548.

When we create the firewall rules with kubetest2 gke deployer, its name must be within 63 characters, otherwise gcloud will throw an error. Since we are currently using projects IDs to derive the firewall rule names, there's possibility we will get the error, see an example in https://prow-gob.gcpnode.com/view/gs/gob-prow/logs/asm-networking-gke-mp_istio_release-1.8_periodic/1338576875852664832#1:build-log.txt%3A357

Using project numbers shortens the maximum name length such that it will be <= 63 characters.