### PR TITLE
Fix kind deployer build type

### DIFF
--- a/kubetest2-kind/deployer/deployer.go
+++ b/kubetest2-kind/deployer/deployer.go
@@ -88,7 +88,7 @@ func bindFlags(d *deployer) *pflag.FlagSet {
 		&d.nodeImage, "image-name", "", "the image name to use for build and up",
 	)
 	flags.StringVar(
-		&d.nodeImage, "build-type", "", "--type for kind build node-image",
+		&d.buildType, "build-type", "", "--type for kind build node-image",
 	)
 	flags.StringVar(
 		&d.configPath, "config", "", "--config for kind create cluster",


### PR DESCRIPTION
Building a kind node image with bazel wasn't working since the
`--build-type` flag was reading the nodeImage argument incorrectly. This
fixes the flag parsing to ensure the result of `--build-type` will be
correctly stored in deployer's buildType field.