### PR TITLE
Expose the ginkgo test package marker as a flag

### DIFF
--- a/pkg/testers/ginkgo/ginkgo.go
+++ b/pkg/testers/ginkgo/ginkgo.go
@@ -43,6 +43,7 @@ type Tester struct {
 	TestPackageVersion string `desc:"The ginkgo tester uses a test package made during the kubernetes build. The tester downloads this test package from one of the release tars published to GCS. Defaults to latest. Use \"gsutil ls gs://kubernetes-release/release/\" to find release names. Example: v1.20.0-alpha.0"`
 	TestPackageBucket  string `desc:"The bucket which release tars will be downloaded from to acquire the test package. Defaults to the main kubernetes project bucket."`
 	TestPackageDir     string `desc:"The directory in the bucket which represents the type of release. Default to the release directory."`
+	TestPackageMarker  string `desc:"The version marker in the directory containing the package version to download when unspecified. Defaults to latest.txt."`
 	TestArgs           string `desc:"Additional arguments supported by the e2e test framework (https://godoc.org/k8s.io/kubernetes/test/e2e/framework#TestContextType)."`
 
 	kubeconfigPath string
@@ -136,6 +137,7 @@ func NewDefaultTester() *Tester {
 		Parallel:          1,
 		TestPackageBucket: "kubernetes-release",
 		TestPackageDir:    "release",
+		TestPackageMarker: "latest.txt",
 	}
 }
 

--- a/pkg/testers/ginkgo/package.go
+++ b/pkg/testers/ginkgo/package.go
@@ -41,7 +41,7 @@ func (t *Tester) AcquireTestPackage() error {
 		cmd := exec.Command(
 			"gsutil",
 			"cat",
-			fmt.Sprintf("gs://%s/%s/latest.txt", t.TestPackageBucket, t.TestPackageDir),
+			fmt.Sprintf("gs://%s/%s/%s", t.TestPackageBucket, t.TestPackageDir, t.TestPackageMarker),
 		)
 		lines, err := exec.OutputLines(cmd)
 		if err != nil {
@@ -52,7 +52,7 @@ func (t *Tester) AcquireTestPackage() error {
 		}
 		t.TestPackageVersion = lines[0]
 
-		klog.V(1).Infof("Test package version was not specified. Defaulting to latest: %s", t.TestPackageVersion)
+		klog.V(1).Infof("Test package version was not specified. Defaulting to version from %s: %s", t.TestPackageMarker, t.TestPackageVersion)
 	}
 
 	releaseTar := fmt.Sprintf("kubernetes-test-%s-%s.tar.gz", runtime.GOOS, runtime.GOARCH)


### PR DESCRIPTION
This allows `latest.txt` to be overridden to support testing release branches with `latest-1.20.txt` for example.