### PR TITLE
Log the commands before running them for easier debugging

### DIFF
--- a/kubetest2-gke/deployer/up.go
+++ b/kubetest2-gke/deployer/up.go
@@ -105,7 +105,6 @@ func (d *deployer) Up() error {
 				args = append(args, subNetworkArgs...)
 				args = append(args, privateClusterArgs...)
 				args = append(args, cluster.name)
-				klog.V(1).Infof("Gcloud command: gcloud %+v\n", args)
 				if err := runWithOutput(exec.CommandContext(ctx, "gcloud", args...)); err != nil {
 					// Cancel the context to kill other cluster creation processes if any error happens.
 					cancel()

--- a/pkg/exec/local.go
+++ b/pkg/exec/local.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"io"
 	osexec "os/exec"
+	"strings"
+
+	"k8s.io/klog"
 )
 
 // LocalCmd wraps os/exec.Cmd, implementing the exec.Cmd interface
@@ -36,6 +39,7 @@ var _ Cmder = &LocalCmder{}
 
 // Command returns a new exec.Cmd backed by Cmd
 func (c *LocalCmder) Command(name string, arg ...string) Cmd {
+	klog.V(2).Infof("⚙️ %s %s", name, strings.Join(arg, " "))
 	return &LocalCmd{
 		Cmd: osexec.Command(name, arg...),
 	}
@@ -43,6 +47,7 @@ func (c *LocalCmder) Command(name string, arg ...string) Cmd {
 
 // CommandContext returns a new exec.Cmd with the context, backed by Cmd
 func (c *LocalCmder) CommandContext(ctx context.Context, name string, arg ...string) Cmd {
+	klog.V(2).Infof("⚙️ %s %s", name, strings.Join(arg, " "))
 	return &LocalCmd{
 		Cmd: osexec.CommandContext(ctx, name, arg...),
 	}


### PR DESCRIPTION
Sometimes we want to debug issues related to `kubetest2` but it's pretty hard to dig out the commands that were run during the process. This PR will log the commands before running them for easier debugging.