### PR TITLE
Allow setting backup regions and zones when creating GKE clusters and a few other fixes

### DIFF
--- a/kubetest2-gke/deployer/build.go
+++ b/kubetest2-gke/deployer/build.go
@@ -57,7 +57,7 @@ func (d *deployer) Build() error {
 	version += "+" + d.commonOptions.RunID()
 	if d.BuildOptions.StageLocation != "" {
 		if err := d.BuildOptions.Stage(version); err != nil {
-			return fmt.Errorf("error staging build: %v", err)
+			return fmt.Errorf("error staging build: %w", err)
 		}
 	}
 	d.Version = version

--- a/kubetest2-gke/deployer/down.go
+++ b/kubetest2-gke/deployer/down.go
@@ -39,7 +39,7 @@ func (d *deployer) Down() error {
 			project := d.projects[i]
 			for j := range d.projectClustersLayout[project] {
 				cluster := d.projectClustersLayout[project][j]
-				loc := location(d.region, d.zone)
+				loc := locationFlag(d.region, d.zone)
 
 				wg.Add(1)
 				go func() {

--- a/kubetest2-gke/deployer/firewall.go
+++ b/kubetest2-gke/deployer/firewall.go
@@ -73,7 +73,7 @@ func ensureFirewallRulesForSingleProject(project, network string, clusters []clu
 			"--network="+network,
 			"--allow="+e2eAllow,
 			"--target-tags="+tag)); err != nil {
-			return fmt.Errorf("error creating e2e firewall rule: %v", err)
+			return fmt.Errorf("error creating e2e firewall rule: %w", err)
 		}
 	}
 	return nil
@@ -111,7 +111,7 @@ func ensureFirewallRulesForMultiProjects(projects []string, network string, subn
 			"--allow=tcp,udp,icmp",
 			"--direction=INGRESS",
 			"--source-ranges="+sourceRanges)); err != nil {
-			return fmt.Errorf("error creating firewall rule for project %q: %v", curtProject, err)
+			return fmt.Errorf("error creating firewall rule for project %q: %w", curtProject, err)
 		}
 	}
 	return nil
@@ -140,7 +140,7 @@ func (d *deployer) cleanupNetworkFirewalls(hostProject, network string) (int, er
 		commandArgs = append(commandArgs, "--project="+hostProject)
 		errFirewall := runWithOutput(exec.Command("gcloud", commandArgs...))
 		if errFirewall != nil {
-			return 0, fmt.Errorf("error deleting firewall: %v", errFirewall)
+			return 0, fmt.Errorf("error deleting firewall: %w", errFirewall)
 		}
 		// It looks sometimes gcloud exits before the firewall rules are actually deleted,
 		// so sleep 30 seconds to wait for the firewall rules being deleted completely.
@@ -159,7 +159,7 @@ func (d *deployer) getInstanceGroups() error {
 	// Initialize project instance groups structure
 	d.instanceGroups = map[string]map[string][]*ig{}
 
-	location := location(d.region, d.zone)
+	location := locationFlag(d.region, d.zone)
 
 	for _, project := range d.projects {
 		d.instanceGroups[project] = map[string][]*ig{}

--- a/kubetest2-gke/deployer/options/build.go
+++ b/kubetest2-gke/deployer/options/build.go
@@ -51,7 +51,7 @@ func (bo *BuildOptions) implementationFromStrategy() error {
 			ImageLocation: "",
 		}
 	default:
-		return fmt.Errorf("unknown build strategy: %v", bo.Strategy)
+		return fmt.Errorf("unknown build strategy: %q", bo.Strategy)
 	}
 	return nil
 }

--- a/kubetest2-gke/deployer/options/up.go
+++ b/kubetest2-gke/deployer/options/up.go
@@ -25,7 +25,7 @@ type UpOptions struct {
 func (uo *UpOptions) Validate() error {
 	// allow max 99 clusters (should be sufficient for most use cases)
 	if uo.NumClusters < 1 || uo.NumClusters > 99 {
-		return fmt.Errorf("need to specify between 1 and 99 clusters got %q: ", uo.NumClusters)
+		return fmt.Errorf("need to specify between 1 and 99 clusters got %q", uo.NumClusters)
 	}
 	return nil
 }

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -116,6 +116,12 @@ func CombinedOutputLines(cmd Cmd) (lines []string, err error) {
 	return lines, err
 }
 
+// SetOutput sets cmd's output to write to the given Writer.
+func SetOutput(cmd Cmd, stdoutWriter, stderrWriter io.Writer) {
+	cmd.SetStdout(stdoutWriter)
+	cmd.SetStderr(stderrWriter)
+}
+
 // InheritOutput sets cmd's output to write to the current process's stdout and stderr
 func InheritOutput(cmd Cmd) {
 	cmd.SetStderr(os.Stderr)

--- a/pkg/exec/local.go
+++ b/pkg/exec/local.go
@@ -39,7 +39,7 @@ var _ Cmder = &LocalCmder{}
 
 // Command returns a new exec.Cmd backed by Cmd
 func (c *LocalCmder) Command(name string, arg ...string) Cmd {
-	klog.V(2).Infof("⚙️ %s %s", name, strings.Join(arg, " "))
+	klog.V(1).Infof("⚙️ %s %s", name, strings.Join(arg, " "))
 	return &LocalCmd{
 		Cmd: osexec.Command(name, arg...),
 	}
@@ -47,7 +47,7 @@ func (c *LocalCmder) Command(name string, arg ...string) Cmd {
 
 // CommandContext returns a new exec.Cmd with the context, backed by Cmd
 func (c *LocalCmder) CommandContext(ctx context.Context, name string, arg ...string) Cmd {
-	klog.V(2).Infof("⚙️ %s %s", name, strings.Join(arg, " "))
+	klog.V(1).Infof("⚙️ %s %s", name, strings.Join(arg, " "))
 	return &LocalCmd{
 		Cmd: osexec.CommandContext(ctx, name, arg...),
 	}


### PR DESCRIPTION
This PR includes a few changes:

1. Allow setting backup regions and zones when creating GKE clusters. And when specific errors happen, retry creating the clusters in these backup regions/zones. This is important since a lot of infra flakes are caused by these errors, and there is not a good way to prevent them except retrying, see more details in the internal issue 162609408

2. Change the log level for logging the commands from `2` to `1`, since they are more important than the level `2` logging

3. Fix a bug when running kubetest2-gke only with `--down` but not `--up` flag

4. A few other small coding style improvements and cleanups