### PR TITLE
Add testsuite name in the generated junit-runner.xml file

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -67,7 +67,7 @@ func RealMain(opts types.Options, d types.Deployer, tester types.Tester) (result
 	if err != nil {
 		return errors.Wrap(err, "could not create runner output")
 	}
-	writer := metadata.NewWriter(junitRunner)
+	writer := metadata.NewWriter("kubetest2", junitRunner)
 	// defer writing out the metadata on exit
 	// NOTE: defer is LIFO, so this should actually be the finish time
 	defer func() {

--- a/pkg/metadata/junit.go
+++ b/pkg/metadata/junit.go
@@ -56,6 +56,7 @@ func NewJUnitError(inner error, systemOut string) error {
 // A build (column in testgrid) is composed of one or more TestSuites.
 type testSuite struct {
 	XMLName  xml.Name `xml:"testsuite"`
+	Name     string   `xml:"name,attr"`
 	Failures int      `xml:"failures,attr"`
 	Tests    int      `xml:"tests,attr"`
 	Time     float64  `xml:"time,attr"`

--- a/pkg/metadata/writer.go
+++ b/pkg/metadata/writer.go
@@ -33,8 +33,8 @@ type Writer struct {
 // NewWriter constructs a new writer, the junit_runner.xml contents
 // will be written to runnerOut, with the top level kubetest2 stages as
 // metadata (Up, Down, etc.)
-func NewWriter(runnerOut io.Writer) *Writer {
-	suite := testSuite{}
+func NewWriter(suiteName string, runnerOut io.Writer) *Writer {
+	suite := testSuite{Name: suiteName}
 	return &Writer{
 		suite:     suite,
 		runnerOut: runnerOut,

--- a/pkg/metadata/writer_test.go
+++ b/pkg/metadata/writer_test.go
@@ -72,7 +72,7 @@ func TestWriter(t *testing.T) {
 			},
 			expectedOutput: strings.TrimPrefix(
 				`
-<?xml version="1.0" encoding="UTF-8"?><testsuite failures="0" tests="1" time="3">
+<?xml version="1.0" encoding="UTF-8"?><testsuite name="kubetest2" failures="0" tests="1" time="3">
     <testcase name="noop" time="1"></testcase>
 </testsuite>`,
 				"\n",
@@ -89,7 +89,7 @@ func TestWriter(t *testing.T) {
 			},
 			expectedOutput: strings.TrimPrefix(
 				`
-<?xml version="1.0" encoding="UTF-8"?><testsuite failures="1" tests="1" time="3">
+<?xml version="1.0" encoding="UTF-8"?><testsuite name="kubetest2" failures="1" tests="1" time="3">
     <testcase name="always fails" time="1">
         <failure>oh noes</failure>
     </testcase>
@@ -113,7 +113,7 @@ func TestWriter(t *testing.T) {
 			},
 			expectedOutput: strings.TrimPrefix(
 				`
-<?xml version="1.0" encoding="UTF-8"?><testsuite failures="1" tests="1" time="3">
+<?xml version="1.0" encoding="UTF-8"?><testsuite name="kubetest2" failures="1" tests="1" time="3">
     <testcase name="always fails (junitError)" time="1">
         <failure>on noes</failure>
         <system-out>uh oh</system-out>
@@ -146,7 +146,7 @@ func TestWriter(t *testing.T) {
 			},
 			expectedOutput: strings.TrimPrefix(
 				`
-<?xml version="1.0" encoding="UTF-8"?><testsuite failures="1" tests="3" time="7">
+<?xml version="1.0" encoding="UTF-8"?><testsuite name="kubetest2" failures="1" tests="3" time="7">
     <testcase name="noop" time="1"></testcase>
     <testcase name="noop2" time="1"></testcase>
     <testcase name="always fails (junitError)" time="1">
@@ -166,7 +166,7 @@ func TestWriter(t *testing.T) {
 			// fake output io.WriteCloser
 			runnerOut := bytes.NewBuffer([]byte{})
 			// create a new writer and fake out the time
-			w := NewWriter(runnerOut)
+			w := NewWriter("kubetest2", runnerOut)
 			w.timeNow = makeFakeNow()
 			w.start = w.timeNow()
 			// run all the steps


### PR DESCRIPTION
Some tools would be unhappy if the testsuite in the JUnit XML files does not have a name. This PR adds `kubetest2` as the testsuite name in the generated `junit-runner.xml` file.