### PR TITLE
Extend support for testing from locally built artifacts

### DIFF
--- a/kubetest2-gce/deployer/build.go
+++ b/kubetest2-gce/deployer/build.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"k8s.io/klog"
+	"sigs.k8s.io/kubetest2/pkg/build"
 
 	"sigs.k8s.io/kubetest2/pkg/exec"
 )
@@ -56,6 +57,7 @@ func (d *deployer) Build() error {
 				return fmt.Errorf("error staging build: %v", err)
 			}
 		}
+		build.StoreCommonBinaries(d.RepoRoot, d.commonOptions.RunDir())
 	} else {
 		// this code path supports the kubernetes/cloud-provider-gcp build
 		klog.V(2).Info("starting the build")

--- a/kubetest2-gce/deployer/build.go
+++ b/kubetest2-gce/deployer/build.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 
 	"k8s.io/klog"
-	"sigs.k8s.io/kubetest2/pkg/build"
 
+	"sigs.k8s.io/kubetest2/pkg/build"
 	"sigs.k8s.io/kubetest2/pkg/exec"
 )
 

--- a/kubetest2-gce/deployer/common.go
+++ b/kubetest2-gce/deployer/common.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"k8s.io/klog"
+
 	"sigs.k8s.io/kubetest2/pkg/boskos"
 )
 

--- a/kubetest2-gce/deployer/common.go
+++ b/kubetest2-gce/deployer/common.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"time"
 
 	"k8s.io/klog"
@@ -45,7 +46,7 @@ func (d *deployer) initialize() error {
 	}
 
 	if d.commonOptions.ShouldUp() || d.commonOptions.ShouldDown() {
-		path, err := verifyKubectl()
+		path, err := d.verifyKubectl()
 		if err != nil {
 			return err
 		}
@@ -188,12 +189,17 @@ func getClusterIPRange(numNodes int) string {
 	return suggestedRange
 }
 
-// verifyKubectl checks if kubectl exists in PATH
+// verifyKubectl checks if kubectl exists in kubetest2 artifacts or PATH
 // returns the path to the binary, error if it doesn't exist
 // kubectl detection using legacy verify-get-kube-binaries is unreliable
 // https://github.com/kubernetes/kubernetes/blob/b10d82b93bad7a4e39b9d3f5c5e81defa3af68f0/cluster/kubectl.sh#L25-L26
-func verifyKubectl() (string, error) {
-	klog.V(2).Infof("checking existence of kubectl in $PATH ...")
+func (d *deployer) verifyKubectl() (string, error) {
+	klog.V(2).Infof("checking locally built kubectl ...")
+	localKubectl := filepath.Join(d.commonOptions.RunDir(), "kubectl")
+	if _, err := os.Stat(localKubectl); err == nil {
+		return localKubectl, nil
+	}
+	klog.V(2).Infof("could not find locally built kubectl, checking existence of kubectl in $PATH ...")
 	kubectlPath, err := exec.LookPath("kubectl")
 	if err != nil {
 		return "", fmt.Errorf("could not find kubectl in $PATH, please ensure your environment has the kubectl binary")

--- a/kubetest2-gke/deployer/build.go
+++ b/kubetest2-gke/deployer/build.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"k8s.io/klog"
+
 	"sigs.k8s.io/kubetest2/pkg/build"
 )
 

--- a/kubetest2-gke/deployer/build.go
+++ b/kubetest2-gke/deployer/build.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"k8s.io/klog"
+	"sigs.k8s.io/kubetest2/pkg/build"
 )
 
 var (
@@ -82,6 +83,7 @@ func (d *deployer) Build() error {
 		}
 	}
 	d.Version = version
+	build.StoreCommonBinaries(d.RepoRoot, d.commonOptions.RunDir())
 	return nil
 }
 

--- a/kubetest2-gke/deployer/deployer.go
+++ b/kubetest2-gke/deployer/deployer.go
@@ -167,7 +167,7 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 			CommonBuildOptions: &build.Options{
 				Builder:  &build.NoopBuilder{},
 				Stager:   &build.NoopStager{},
-				Strategy: "bazel",
+				Strategy: "make",
 			},
 		},
 		UpOptions: &options.UpOptions{

--- a/kubetest2-gke/deployer/deployer.go
+++ b/kubetest2-gke/deployer/deployer.go
@@ -31,7 +31,6 @@ import (
 
 	"sigs.k8s.io/kubetest2/kubetest2-gke/deployer/options"
 	"sigs.k8s.io/kubetest2/pkg/build"
-
 	"sigs.k8s.io/kubetest2/pkg/types"
 )
 

--- a/kubetest2-kind/deployer/build.go
+++ b/kubetest2-kind/deployer/build.go
@@ -22,22 +22,18 @@ import (
 )
 
 func (d *deployer) Build() error {
-	// TODO(bentheelder): build type should be configurable
 	args := []string{
 		"build", "node-image",
 	}
-	if d.logLevel != "" {
-		args = append(args, "--loglevel", d.logLevel)
+	if d.BuildType != "" {
+		args = append(args, "--type", d.BuildType)
 	}
-	if d.buildType != "" {
-		args = append(args, "--type", d.buildType)
-	}
-	if d.kubeRoot != "" {
-		args = append(args, "--kube-root", d.kubeRoot)
+	if d.KubeRoot != "" {
+		args = append(args, "--kube-root", d.KubeRoot)
 	}
 	// set the explicitly specified image name if set
-	if d.nodeImage != "" {
-		args = append(args, "--image", d.nodeImage)
+	if d.NodeImage != "" {
+		args = append(args, "--image", d.NodeImage)
 	} else if d.commonOptions.ShouldBuild() {
 		// otherwise if we just built an image, use that
 		args = append(args, "--image", kindDefaultBuiltImageName)

--- a/kubetest2-kind/deployer/build.go
+++ b/kubetest2-kind/deployer/build.go
@@ -18,6 +18,8 @@ package deployer
 import (
 	"os"
 
+	"k8s.io/klog"
+	"sigs.k8s.io/kubetest2/pkg/build"
 	"sigs.k8s.io/kubetest2/pkg/process"
 )
 
@@ -39,7 +41,11 @@ func (d *deployer) Build() error {
 		args = append(args, "--image", kindDefaultBuiltImageName)
 	}
 
-	println("Build(): building kind node image...\n")
+	klog.V(0).Infof("Build(): building kind node image...\n")
 	// we want to see the output so use process.ExecJUnit
-	return process.ExecJUnit("kind", args, os.Environ())
+	if err := process.ExecJUnit("kind", args, os.Environ()); err != nil {
+		return err
+	}
+	build.StoreCommonBinaries(d.KubeRoot, d.commonOptions.RunDir())
+	return nil
 }

--- a/kubetest2-kind/deployer/build.go
+++ b/kubetest2-kind/deployer/build.go
@@ -19,6 +19,7 @@ import (
 	"os"
 
 	"k8s.io/klog"
+
 	"sigs.k8s.io/kubetest2/pkg/build"
 	"sigs.k8s.io/kubetest2/pkg/process"
 )

--- a/kubetest2-kind/deployer/build.go
+++ b/kubetest2-kind/deployer/build.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package deployer
+
+import (
+	"os"
+
+	"sigs.k8s.io/kubetest2/pkg/process"
+)
+
+func (d *deployer) Build() error {
+	// TODO(bentheelder): build type should be configurable
+	args := []string{
+		"build", "node-image",
+	}
+	if d.logLevel != "" {
+		args = append(args, "--loglevel", d.logLevel)
+	}
+	if d.buildType != "" {
+		args = append(args, "--type", d.buildType)
+	}
+	if d.kubeRoot != "" {
+		args = append(args, "--kube-root", d.kubeRoot)
+	}
+	// set the explicitly specified image name if set
+	if d.nodeImage != "" {
+		args = append(args, "--image", d.nodeImage)
+	} else if d.commonOptions.ShouldBuild() {
+		// otherwise if we just built an image, use that
+		args = append(args, "--image", kindDefaultBuiltImageName)
+	}
+
+	println("Build(): building kind node image...\n")
+	// we want to see the output so use process.ExecJUnit
+	return process.ExecJUnit("kind", args, os.Environ())
+}

--- a/kubetest2-kind/deployer/deployer.go
+++ b/kubetest2-kind/deployer/deployer.go
@@ -18,10 +18,13 @@ limitations under the License.
 package deployer
 
 import (
+	"flag"
 	"os"
 	"path/filepath"
 
+	"github.com/octago/sflags/gen/gpflag"
 	"github.com/spf13/pflag"
+	"k8s.io/klog"
 
 	"sigs.k8s.io/kubetest2/pkg/types"
 )
@@ -47,20 +50,19 @@ type deployer struct {
 	// generic parts
 	commonOptions types.Options
 	// kind specific details
-	nodeImage      string // name of the node image built / deployed
-	clusterName    string // --name flag value for kind
-	logLevel       string // log level for kind commands
-	logsDir        string // dir to export logs to
-	buildType      string // --type flag to kind build node-image
-	configPath     string // --config flag for kind create cluster
-	kubeconfigPath string // --kubeconfig flag for kind create cluster
-	kubeRoot       string // --kube-root for kind build node-image
-	verbosity      int    // --verbosity for kind
+	NodeImage      string `flag:"image-name" desc:"the image name to use for build and up"`
+	ClusterName    string `flag:"cluster-name" desc:"the kind cluster --name"`
+	BuildType      string `desc:"--type for kind build node-image"`
+	ConfigPath     string `flag:"config" desc:"--config for kind create cluster"`
+	KubeconfigPath string `flag:"kubeconfig" desc:"--kubeconfig flag for kind create cluster"`
+	KubeRoot       string `desc:"--kube-root for kind build node-image"`
+
+	logsDir string
 }
 
 func (d *deployer) Kubeconfig() (string, error) {
-	if d.kubeconfigPath != "" {
-		return d.kubeconfigPath, nil
+	if d.KubeconfigPath != "" {
+		return d.KubeconfigPath, nil
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -71,31 +73,15 @@ func (d *deployer) Kubeconfig() (string, error) {
 
 // helper used to create & bind a flagset to the deployer
 func bindFlags(d *deployer) *pflag.FlagSet {
-	flags := pflag.NewFlagSet(Name, pflag.ContinueOnError)
-	flags.StringVar(
-		&d.clusterName, "cluster-name", "kind-kubetest2", "the kind cluster --name",
-	)
-	flags.StringVar(
-		&d.logLevel, "loglevel", "", "--loglevel for kind commands",
-	)
-	flags.StringVar(
-		&d.nodeImage, "image-name", "", "the image name to use for build and up",
-	)
-	flags.StringVar(
-		&d.buildType, "build-type", "", "--type for kind build node-image",
-	)
-	flags.StringVar(
-		&d.configPath, "config", "", "--config for kind create cluster",
-	)
-	flags.StringVar(
-		&d.kubeconfigPath, "kubeconfig", "", "--kubeconfig flag for kind create cluster",
-	)
-	flags.StringVar(
-		&d.kubeRoot, "kube-root", "", "--kube-root flag for kind build node-image",
-	)
-	flags.IntVar(
-		&d.verbosity, "verbosity", 0, "--verbosity flag for kind",
-	)
+	flags, err := gpflag.Parse(d)
+	if err != nil {
+		klog.Fatalf("unable to generate flags from deployer")
+		return nil
+	}
+
+	klog.InitFlags(nil)
+	flags.AddGoFlagSet(flag.CommandLine)
+
 	return flags
 }
 

--- a/kubetest2-kind/deployer/deployer.go
+++ b/kubetest2-kind/deployer/deployer.go
@@ -20,14 +20,9 @@ package deployer
 import (
 	"os"
 	"path/filepath"
-	"strconv"
-	"strings"
 
 	"github.com/spf13/pflag"
 
-	"sigs.k8s.io/kubetest2/pkg/exec"
-	"sigs.k8s.io/kubetest2/pkg/metadata"
-	"sigs.k8s.io/kubetest2/pkg/process"
 	"sigs.k8s.io/kubetest2/pkg/types"
 )
 
@@ -48,7 +43,6 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 // assert that New implements types.NewDeployer
 var _ types.NewDeployer = New
 
-// TODO(bentheelder): finish implementing this stubbed-out deployer
 type deployer struct {
 	// generic parts
 	commonOptions types.Options
@@ -107,107 +101,6 @@ func bindFlags(d *deployer) *pflag.FlagSet {
 
 // assert that deployer implements types.DeployerWithKubeconfig
 var _ types.DeployerWithKubeconfig = &deployer{}
-
-// Deployer implementation methods below
-
-func (d *deployer) Up() error {
-	args := []string{
-		"create", "cluster",
-		"--name", d.clusterName,
-	}
-	if d.logLevel != "" {
-		args = append(args, "--loglevel", d.logLevel)
-	}
-	// set the explicitly specified image name if set
-	if d.nodeImage != "" {
-		args = append(args, "--image", d.nodeImage)
-	} else if d.commonOptions.ShouldBuild() {
-		// otherwise if we just built an image, use that
-		// NOTE: this is safe in the face of upstream changes, because
-		// we use the same logic / constant for Build()
-		args = append(args, "--image", kindDefaultBuiltImageName)
-	}
-	if d.configPath != "" {
-		args = append(args, "--config", d.configPath)
-	}
-	if d.kubeconfigPath != "" {
-		args = append(args, "--kubeconfig", d.kubeconfigPath)
-	}
-	if d.verbosity > 0 {
-		args = append(args, "--verbosity", strconv.Itoa(d.verbosity))
-	}
-
-	println("Up(): creating kind cluster...\n")
-	// we want to see the output so use process.ExecJUnit
-	return process.ExecJUnit("kind", args, os.Environ())
-}
-
-func (d *deployer) Down() error {
-	args := []string{
-		"delete", "cluster",
-		"--name", d.clusterName,
-	}
-	if d.logLevel != "" {
-		args = append(args, "--loglevel", d.logLevel)
-	}
-
-	println("Down(): deleting kind cluster...\n")
-	// we want to see the output so use process.ExecJUnit
-	return process.ExecJUnit("kind", args, os.Environ())
-}
-
-func (d *deployer) IsUp() (up bool, err error) {
-	// naively assume that if the api server reports nodes, the cluster is up
-	lines, err := exec.CombinedOutputLines(
-		exec.Command("kubectl", "get", "nodes", "-o=name"),
-	)
-	if err != nil {
-		return false, metadata.NewJUnitError(err, strings.Join(lines, "\n"))
-	}
-	return len(lines) > 0, nil
-}
-
-func (d *deployer) DumpClusterLogs() error {
-	args := []string{
-		"export", "logs",
-		"--name", d.clusterName,
-		d.logsDir,
-	}
-	if d.logLevel != "" {
-		args = append(args, "--loglevel", d.logLevel)
-	}
-
-	println("DumpClusterLogs(): exporting kind cluster logs...\n")
-	// we want to see the output so use process.ExecJUnit
-	return process.ExecJUnit("kind", args, os.Environ())
-}
-
-func (d *deployer) Build() error {
-	// TODO(bentheelder): build type should be configurable
-	args := []string{
-		"build", "node-image",
-	}
-	if d.logLevel != "" {
-		args = append(args, "--loglevel", d.logLevel)
-	}
-	if d.buildType != "" {
-		args = append(args, "--type", d.buildType)
-	}
-	if d.kubeRoot != "" {
-		args = append(args, "--kube-root", d.kubeRoot)
-	}
-	// set the explicitly specified image name if set
-	if d.nodeImage != "" {
-		args = append(args, "--image", d.nodeImage)
-	} else if d.commonOptions.ShouldBuild() {
-		// otherwise if we just built an image, use that
-		args = append(args, "--image", kindDefaultBuiltImageName)
-	}
-
-	println("Build(): building kind node image...\n")
-	// we want to see the output so use process.ExecJUnit
-	return process.ExecJUnit("kind", args, os.Environ())
-}
 
 // well-known kind related constants
 const kindDefaultBuiltImageName = "kindest/node:latest"

--- a/kubetest2-kind/deployer/down.go
+++ b/kubetest2-kind/deployer/down.go
@@ -19,6 +19,7 @@ import (
 	"os"
 
 	"k8s.io/klog"
+
 	"sigs.k8s.io/kubetest2/pkg/process"
 )
 

--- a/kubetest2-kind/deployer/down.go
+++ b/kubetest2-kind/deployer/down.go
@@ -18,6 +18,7 @@ package deployer
 import (
 	"os"
 
+	"k8s.io/klog"
 	"sigs.k8s.io/kubetest2/pkg/process"
 )
 
@@ -27,7 +28,7 @@ func (d *deployer) Down() error {
 		"--name", d.ClusterName,
 	}
 
-	println("Down(): deleting kind cluster...\n")
+	klog.V(0).Infof("Down(): deleting kind cluster...\n")
 	// we want to see the output so use process.ExecJUnit
 	return process.ExecJUnit("kind", args, os.Environ())
 }

--- a/kubetest2-kind/deployer/down.go
+++ b/kubetest2-kind/deployer/down.go
@@ -24,10 +24,7 @@ import (
 func (d *deployer) Down() error {
 	args := []string{
 		"delete", "cluster",
-		"--name", d.clusterName,
-	}
-	if d.logLevel != "" {
-		args = append(args, "--loglevel", d.logLevel)
+		"--name", d.ClusterName,
 	}
 
 	println("Down(): deleting kind cluster...\n")

--- a/kubetest2-kind/deployer/down.go
+++ b/kubetest2-kind/deployer/down.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package deployer
+
+import (
+	"os"
+
+	"sigs.k8s.io/kubetest2/pkg/process"
+)
+
+func (d *deployer) Down() error {
+	args := []string{
+		"delete", "cluster",
+		"--name", d.clusterName,
+	}
+	if d.logLevel != "" {
+		args = append(args, "--loglevel", d.logLevel)
+	}
+
+	println("Down(): deleting kind cluster...\n")
+	// we want to see the output so use process.ExecJUnit
+	return process.ExecJUnit("kind", args, os.Environ())
+}

--- a/kubetest2-kind/deployer/dumplogs.go
+++ b/kubetest2-kind/deployer/dumplogs.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package deployer
+
+import (
+	"os"
+
+	"sigs.k8s.io/kubetest2/pkg/process"
+)
+
+func (d *deployer) DumpClusterLogs() error {
+	args := []string{
+		"export", "logs",
+		"--name", d.clusterName,
+		d.logsDir,
+	}
+	if d.logLevel != "" {
+		args = append(args, "--loglevel", d.logLevel)
+	}
+
+	println("DumpClusterLogs(): exporting kind cluster logs...\n")
+	// we want to see the output so use process.ExecJUnit
+	return process.ExecJUnit("kind", args, os.Environ())
+}

--- a/kubetest2-kind/deployer/dumplogs.go
+++ b/kubetest2-kind/deployer/dumplogs.go
@@ -19,6 +19,7 @@ import (
 	"os"
 
 	"k8s.io/klog"
+
 	"sigs.k8s.io/kubetest2/pkg/process"
 )
 

--- a/kubetest2-kind/deployer/dumplogs.go
+++ b/kubetest2-kind/deployer/dumplogs.go
@@ -24,11 +24,8 @@ import (
 func (d *deployer) DumpClusterLogs() error {
 	args := []string{
 		"export", "logs",
-		"--name", d.clusterName,
+		"--name", d.ClusterName,
 		d.logsDir,
-	}
-	if d.logLevel != "" {
-		args = append(args, "--loglevel", d.logLevel)
 	}
 
 	println("DumpClusterLogs(): exporting kind cluster logs...\n")

--- a/kubetest2-kind/deployer/dumplogs.go
+++ b/kubetest2-kind/deployer/dumplogs.go
@@ -18,6 +18,7 @@ package deployer
 import (
 	"os"
 
+	"k8s.io/klog"
 	"sigs.k8s.io/kubetest2/pkg/process"
 )
 
@@ -28,7 +29,7 @@ func (d *deployer) DumpClusterLogs() error {
 		d.logsDir,
 	}
 
-	println("DumpClusterLogs(): exporting kind cluster logs...\n")
+	klog.V(0).Infof("DumpClusterLogs(): exporting kind cluster logs...\n")
 	// we want to see the output so use process.ExecJUnit
 	return process.ExecJUnit("kind", args, os.Environ())
 }

--- a/kubetest2-kind/deployer/up.go
+++ b/kubetest2-kind/deployer/up.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"k8s.io/klog"
+
 	"sigs.k8s.io/kubetest2/pkg/exec"
 	"sigs.k8s.io/kubetest2/pkg/metadata"
 	"sigs.k8s.io/kubetest2/pkg/process"

--- a/kubetest2-kind/deployer/up.go
+++ b/kubetest2-kind/deployer/up.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package deployer
+
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	"sigs.k8s.io/kubetest2/pkg/exec"
+	"sigs.k8s.io/kubetest2/pkg/metadata"
+	"sigs.k8s.io/kubetest2/pkg/process"
+)
+
+func (d *deployer) IsUp() (up bool, err error) {
+	// naively assume that if the api server reports nodes, the cluster is up
+	lines, err := exec.CombinedOutputLines(
+		exec.Command("kubectl", "get", "nodes", "-o=name"),
+	)
+	if err != nil {
+		return false, metadata.NewJUnitError(err, strings.Join(lines, "\n"))
+	}
+	return len(lines) > 0, nil
+}
+
+func (d *deployer) Up() error {
+	args := []string{
+		"create", "cluster",
+		"--name", d.clusterName,
+	}
+	if d.logLevel != "" {
+		args = append(args, "--loglevel", d.logLevel)
+	}
+	// set the explicitly specified image name if set
+	if d.nodeImage != "" {
+		args = append(args, "--image", d.nodeImage)
+	} else if d.commonOptions.ShouldBuild() {
+		// otherwise if we just built an image, use that
+		// NOTE: this is safe in the face of upstream changes, because
+		// we use the same logic / constant for Build()
+		args = append(args, "--image", kindDefaultBuiltImageName)
+	}
+	if d.configPath != "" {
+		args = append(args, "--config", d.configPath)
+	}
+	if d.kubeconfigPath != "" {
+		args = append(args, "--kubeconfig", d.kubeconfigPath)
+	}
+	if d.verbosity > 0 {
+		args = append(args, "--verbosity", strconv.Itoa(d.verbosity))
+	}
+
+	println("Up(): creating kind cluster...\n")
+	// we want to see the output so use process.ExecJUnit
+	return process.ExecJUnit("kind", args, os.Environ())
+}

--- a/kubetest2-kind/deployer/up.go
+++ b/kubetest2-kind/deployer/up.go
@@ -17,7 +17,6 @@ package deployer
 
 import (
 	"os"
-	"strconv"
 	"strings"
 
 	"sigs.k8s.io/kubetest2/pkg/exec"
@@ -39,28 +38,23 @@ func (d *deployer) IsUp() (up bool, err error) {
 func (d *deployer) Up() error {
 	args := []string{
 		"create", "cluster",
-		"--name", d.clusterName,
+		"--name", d.ClusterName,
 	}
-	if d.logLevel != "" {
-		args = append(args, "--loglevel", d.logLevel)
-	}
+
 	// set the explicitly specified image name if set
-	if d.nodeImage != "" {
-		args = append(args, "--image", d.nodeImage)
+	if d.NodeImage != "" {
+		args = append(args, "--image", d.NodeImage)
 	} else if d.commonOptions.ShouldBuild() {
 		// otherwise if we just built an image, use that
 		// NOTE: this is safe in the face of upstream changes, because
 		// we use the same logic / constant for Build()
 		args = append(args, "--image", kindDefaultBuiltImageName)
 	}
-	if d.configPath != "" {
-		args = append(args, "--config", d.configPath)
+	if d.ConfigPath != "" {
+		args = append(args, "--config", d.ConfigPath)
 	}
-	if d.kubeconfigPath != "" {
-		args = append(args, "--kubeconfig", d.kubeconfigPath)
-	}
-	if d.verbosity > 0 {
-		args = append(args, "--verbosity", strconv.Itoa(d.verbosity))
+	if d.KubeconfigPath != "" {
+		args = append(args, "--kubeconfig", d.KubeconfigPath)
 	}
 
 	println("Up(): creating kind cluster...\n")

--- a/kubetest2-kind/deployer/up.go
+++ b/kubetest2-kind/deployer/up.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"strings"
 
+	"k8s.io/klog"
 	"sigs.k8s.io/kubetest2/pkg/exec"
 	"sigs.k8s.io/kubetest2/pkg/metadata"
 	"sigs.k8s.io/kubetest2/pkg/process"
@@ -57,7 +58,7 @@ func (d *deployer) Up() error {
 		args = append(args, "--kubeconfig", d.KubeconfigPath)
 	}
 
-	println("Up(): creating kind cluster...\n")
+	klog.V(0).Infof("Up(): creating kind cluster...\n")
 	// we want to see the output so use process.ExecJUnit
 	return process.ExecJUnit("kind", args, os.Environ())
 }

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -124,6 +124,9 @@ func RealMain(opts types.Options, d types.Deployer, tester types.Tester) (result
 
 		envsForTester := os.Environ()
 		// We expose both ARIFACTS and KUBETEST2_RUN_DIR so we can more granular about caching vs output in future.
+		// also add run_dir to $PATH for locally built binaries
+		dollarPath := opts.RunDir() + string(filepath.ListSeparator) + os.Getenv("PATH")
+		envsForTester = append(envsForTester, fmt.Sprintf("%s=%s", "PATH", dollarPath))
 		envsForTester = append(envsForTester, fmt.Sprintf("%s=%s", "ARTIFACTS", opts.RunDir()))
 		envsForTester = append(envsForTester, fmt.Sprintf("%s=%s", "KUBETEST2_RUN_DIR", opts.RunDir()))
 		envsForTester = append(envsForTester, fmt.Sprintf("%s=%s", "KUBETEST2_RUN_ID", opts.RunID()))

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -125,8 +125,8 @@ func RealMain(opts types.Options, d types.Deployer, tester types.Tester) (result
 		envsForTester := os.Environ()
 		// We expose both ARIFACTS and KUBETEST2_RUN_DIR so we can more granular about caching vs output in future.
 		// also add run_dir to $PATH for locally built binaries
-		dollarPath := opts.RunDir() + string(filepath.ListSeparator) + os.Getenv("PATH")
-		envsForTester = append(envsForTester, fmt.Sprintf("%s=%s", "PATH", dollarPath))
+		updatedPath := opts.RunDir() + string(filepath.ListSeparator) + os.Getenv("PATH")
+		envsForTester = append(envsForTester, fmt.Sprintf("%s=%s", "PATH", updatedPath))
 		envsForTester = append(envsForTester, fmt.Sprintf("%s=%s", "ARTIFACTS", opts.RunDir()))
 		envsForTester = append(envsForTester, fmt.Sprintf("%s=%s", "KUBETEST2_RUN_DIR", opts.RunDir()))
 		envsForTester = append(envsForTester, fmt.Sprintf("%s=%s", "KUBETEST2_RUN_ID", opts.RunID()))

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -73,17 +73,20 @@ func sourceVersion(kubeRoot string) (string, error) {
 	return "", fmt.Errorf("could not find kubernetes version in output: %q", strings.Join(output, "\n"))
 }
 
+var (
+	CommonTestBinaries = []string{
+		"kubectl",
+		"e2e.test",
+		"ginkgo",
+	}
+)
+
 // StoreCommonBinaries will best effort try to store commonly built binaries
 // to the output directory
 func StoreCommonBinaries(kuberoot string, outroot string) {
 	const dockerizedOutput = "_output/dockerized"
 	root := filepath.Join(kuberoot, dockerizedOutput, "bin", runtime.GOOS, runtime.GOARCH)
-	commonTestBinaries := []string{
-		"kubectl",
-		"e2e.test",
-		"ginkgo",
-	}
-	for _, binary := range commonTestBinaries {
+	for _, binary := range CommonTestBinaries {
 		source := filepath.Join(root, binary)
 		dest := filepath.Join(outroot, binary)
 		if _, err := os.Stat(source); err == nil {

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fs
+
+import (
+	"io"
+	"os"
+)
+
+// CopyFile copies a file from src to dst
+func CopyFile(src, dst string) (err error) {
+	// get source information
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	return copyFile(src, dst, info)
+}
+
+func copyFile(src, dst string, info os.FileInfo) error {
+	// open src for reading
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	// create dst file
+	// this is like f, err := os.Create(dst); os.Chmod(f.Name(), src.Mode())
+	out, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, info.Mode())
+	if err != nil {
+		return err
+	}
+	// make sure we close the file
+	defer func() {
+		closeErr := out.Close()
+		// if we weren't returning an error
+		if err == nil {
+			err = closeErr
+		}
+	}()
+	// actually copy
+	if _, err = io.Copy(out, in); err != nil {
+		return err
+	}
+	err = out.Sync()
+	return err
+}

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -37,7 +37,13 @@ func copyFile(src, dst string, info os.FileInfo) error {
 	if err != nil {
 		return err
 	}
-	defer in.Close()
+	defer func() {
+		closeErr := in.Close()
+		// if we weren't returning an error
+		if err == nil {
+			err = closeErr
+		}
+	}()
 	// create dst file
 	// this is like f, err := os.Create(dst); os.Chmod(f.Name(), src.Mode())
 	out, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, info.Mode())

--- a/pkg/testers/ginkgo/ginkgo.go
+++ b/pkg/testers/ginkgo/ginkgo.go
@@ -25,9 +25,9 @@ import (
 	"github.com/kballard/go-shellquote"
 	"github.com/octago/sflags/gen/gpflag"
 	"k8s.io/klog"
-	"sigs.k8s.io/kubetest2/pkg/build"
 
 	"sigs.k8s.io/kubetest2/pkg/artifacts"
+	"sigs.k8s.io/kubetest2/pkg/build"
 	"sigs.k8s.io/kubetest2/pkg/exec"
 )
 
@@ -159,13 +159,25 @@ func (t *Tester) Execute() error {
 		return nil
 	}
 
-	t.initKubetest2Info()
+	if err := t.initKubetest2Info(); err != nil {
+		return err
+	}
 	return t.Test()
 }
 
 // initializes relevant information from the well defined kubetest2 environment variables.
-func (t *Tester) initKubetest2Info() {
-	t.runDir = os.Getenv("KUBETEST2_RUN_DIR")
+func (t *Tester) initKubetest2Info() error {
+	if dir, ok := os.LookupEnv("KUBETEST2_RUN_DIR"); ok {
+		t.runDir = dir
+		return nil
+	}
+	// default to current working directory if for some reason the env is not set
+	dir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to set run dir: %v", err)
+	}
+	t.runDir = dir
+	return nil
 }
 
 func NewDefaultTester() *Tester {


### PR DESCRIPTION
Add functionality to the ginkgo tester to be able to test from current builds.
somewhat makes it easier for https://github.com/kubernetes-sigs/kubetest2/issues/87

This will help solve skew problems e.g. kubectl https://testgrid.k8s.io/conformance-all#Conformance%20-%20GCE%20-%20master%20-%20kubetest2

Also refactor kind deployer a bit.

local testing is now as easy as :)

```
kubetest2 kind --build --up --test=ginkgo -- --focus-regex='Kubectl.client.Kubectl.replace.should.update.a.single-container'
```

xref: https://github.com/kubernetes/enhancements/issues/2464

/cc @BenTheElder @spiffxp 
