### PR TITLE
[GCE] Use the cluster configuration from config-test.sh

### DIFF
--- a/kubetest2-gce/deployer/common.go
+++ b/kubetest2-gce/deployer/common.go
@@ -46,14 +46,6 @@ func (d *deployer) initialize() error {
 		}
 	}
 
-	if d.commonOptions.ShouldUp() || d.commonOptions.ShouldDown() {
-		path, err := d.verifyKubectl()
-		if err != nil {
-			return err
-		}
-		d.kubectlPath = path
-	}
-
 	if d.commonOptions.ShouldUp() {
 		if err := d.verifyUpFlags(); err != nil {
 			return fmt.Errorf("init failed to verify flags for up: %s", err)
@@ -169,6 +161,16 @@ func (d *deployer) buildEnv() []string {
 	// KUBECTL_PATH points to the kubectl existing in $PATH
 	// used by the cluster/ scripts
 	env = append(env, fmt.Sprintf("KUBECTL_PATH=%s", d.kubectlPath))
+
+	// KUBE_CONFIG_FILE determines the file to use for setting up configuration for the cluster
+	// https://github.com/kubernetes/kubernetes/blob/3cde6b199900ebc6d6dc415a6036d6fa8fcc1ae0/cluster/gce/util.sh#L19
+	// usually one of
+	// config-default.sh (https://github.com/kubernetes/kubernetes/blob/3cde6b199900ebc6d6dc415a6036d6fa8fcc1ae0/cluster/gce/config-default.sh)
+	// or
+	// config-test.sh (https://github.com/kubernetes/kubernetes/blob/3cde6b199900ebc6d6dc415a6036d6fa8fcc1ae0/cluster/gce/config-test.sh)
+	// here we fix it to config-test.sh since some of the configuration flags are specific to the end-to-end testing scenario
+	// e.g. https://github.com/kubernetes/kubernetes/issues/99480
+	env = append(env, "KUBE_CONFIG_FILE=config-test.sh")
 
 	return env
 }

--- a/kubetest2-gce/deployer/down.go
+++ b/kubetest2-gce/deployer/down.go
@@ -32,6 +32,12 @@ func (d *deployer) Down() error {
 		return fmt.Errorf("down failed to init: %s", err)
 	}
 
+	path, err := d.verifyKubectl()
+	if err != nil {
+		return err
+	}
+	d.kubectlPath = path
+
 	env := d.buildEnv()
 	script := filepath.Join(d.RepoRoot, "cluster", "kube-down.sh")
 	klog.V(2).Infof("About to run script at: %s", script)
@@ -39,8 +45,8 @@ func (d *deployer) Down() error {
 	cmd := exec.Command(script)
 	cmd.SetEnv(env...)
 	exec.InheritOutput(cmd)
-	err := cmd.Run()
-	if err != nil {
+
+	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("error encountered during %s: %s", script, err)
 	}
 


### PR DESCRIPTION
Explicitly set `KUBE_CONFIG_FILE=config-test.sh` similar to kubetest (https://github.com/kubernetes/test-infra/blob/d18ba04e55424699d33a47a066e4883b398c2a27/kubetest/e2e.go#L63)

This is where standard configurations specifically for end-to-end test clusters using kube-up are set.

fixes: https://github.com/kubernetes/kubernetes/issues/99480

xref: https://github.com/kubernetes/enhancements/issues/2464

/cc @BenTheElder @liggitt 