### PR TITLE
[GCE] Explicitly set KUBE_GCE_NETWORK

### DIFF
--- a/kubetest2-gce/deployer/common.go
+++ b/kubetest2-gce/deployer/common.go
@@ -129,9 +129,13 @@ func (d *deployer) buildEnv() []string {
 	// the run of kubetest2 and so should be placed in the artifacts directory
 	env = append(env, fmt.Sprintf("KUBECONFIG=%s", d.kubeconfigPath))
 
-	// kube-up and kube-down get this as a default ("kubernetes") but log-dump
-	// does not. opted to set it manually here for maximum consistency
+	// kube-up and kube-down get this as a default ("kubernetes" / "e2e-test-${USER}")
+	// but log-dump does not, set it explicitly here for maximum consistency
 	env = append(env, fmt.Sprintf("KUBE_GCE_INSTANCE_PREFIX=%s", d.instancePrefix))
+
+	// kube-up and kube-down get this as a default ("default" / "e2e-test-${USER}")
+	// but log-dump does not, set it explicitly here for maximum consistency
+	env = append(env, fmt.Sprintf("KUBE_GCE_NETWORK=%s", d.network))
 
 	// Pass through number of nodes and associated IP range. In the future,
 	// IP range will be configurable.

--- a/kubetest2-gce/deployer/deployer_test.go
+++ b/kubetest2-gce/deployer/deployer_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import "testing"
+
+func TestPseudoUniqueSubstring(t *testing.T) {
+	testCases := []struct {
+		name              string
+		uuid              string
+		expectedSubstring string
+	}{
+		{
+			name:              "actual uuid",
+			uuid:              "09a2565a-7ac6-11eb-a603-2218f636630c",
+			expectedSubstring: "09a2565a-7ac6",
+		},
+		{
+			name:              "<= 13 length uuid",
+			uuid:              "09a2565a-7ac6",
+			expectedSubstring: "09a2565a-7ac6",
+		},
+		{
+			name:              "empty string",
+			uuid:              "",
+			expectedSubstring: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			actualSubstring := pseudoUniqueSubstring(tc.uuid)
+			if actualSubstring != tc.expectedSubstring {
+				t.Errorf("invalid substring: expected %s, but got %s", tc.expectedSubstring, actualSubstring)
+			}
+		})
+	}
+}

--- a/kubetest2-gce/deployer/down.go
+++ b/kubetest2-gce/deployer/down.go
@@ -51,9 +51,9 @@ func (d *deployer) Down() error {
 	}
 
 	klog.V(2).Info("about to delete nodeport firewall rule")
-	if err := d.deleteFirewallRuleNodePort(); err != nil {
-		return fmt.Errorf("failed to delete firewall rule: %s", err)
-	}
+	// best-effort try to delete the explicitly created firewall rules
+	// ideally these should already be deleted by kube-down
+	d.deleteFirewallRuleNodePort()
 
 	if d.boskos != nil {
 		klog.V(2).Info("releasing boskos project")

--- a/kubetest2-gce/deployer/firewall.go
+++ b/kubetest2-gce/deployer/firewall.go
@@ -19,6 +19,7 @@ package deployer
 import (
 	"fmt"
 
+	"k8s.io/klog"
 	"sigs.k8s.io/kubetest2/pkg/exec"
 )
 
@@ -50,7 +51,7 @@ func (d *deployer) createFirewallRuleNodePort() error {
 	return nil
 }
 
-func (d *deployer) deleteFirewallRuleNodePort() error {
+func (d *deployer) deleteFirewallRuleNodePort() {
 	cmd := exec.Command(
 		"gcloud", "compute", "firewall-rules", "delete",
 		"--project", d.GCPProject,
@@ -58,8 +59,6 @@ func (d *deployer) deleteFirewallRuleNodePort() error {
 	)
 	exec.InheritOutput(cmd)
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to delete nodeports firewall rules: %s", err)
+		klog.Warning("failed to delete nodeports firewall rules: might be deleted already?")
 	}
-
-	return nil
 }


### PR DESCRIPTION
fixes: https://github.com/kubernetes-sigs/kubetest2/issues/99

propagates to

https://github.com/kubernetes/kubernetes/blob/0ced9d2854174778163b791038c0a757103455b6/cluster/gce/config-test.sh#L134

Also use a run specific prefix instead of a static one to easily be able to tie back to a run.

xref: https://github.com/kubernetes/enhancements/issues/2464

Tested locally with

```
kubetest2 gce --gcp-project=<my_project> --gcp-zone=<my_zone> --repo-root=<repo_root> --up --test=ginkgo -- --focus-regex='Services.should.be.able.to.create.a.functioning.NodePort.service' --use-built-binaries
```
