### PR TITLE
[Node] Add node-e2e tester

### DIFF
--- a/kubetest2-noop/deployer/deployer.go
+++ b/kubetest2-noop/deployer/deployer.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package deployer implements the kubetest2 kind deployer
+package deployer
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+
+	"github.com/octago/sflags/gen/gpflag"
+	"github.com/spf13/pflag"
+	"k8s.io/klog"
+
+	"sigs.k8s.io/kubetest2/pkg/types"
+)
+
+// Name is the name of the deployer
+const Name = "noop"
+
+// New implements deployer.New for kind
+func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
+	// create a deployer object and set fields that are not flag controlled
+	d := &deployer{
+		commonOptions: opts,
+	}
+	// register flags and return
+	return d, bindFlags(d)
+}
+
+// assert that New implements types.NewDeployer
+var _ types.NewDeployer = New
+
+type deployer struct {
+	// generic parts
+	commonOptions types.Options
+
+	KubeconfigPath string `flag:"kubeconfig" desc:"Absolute path to existing kubeconfig for cluster"`
+}
+
+func (d *deployer) Up() error {
+	return nil
+}
+
+func (d *deployer) Down() error {
+	return nil
+}
+
+func (d *deployer) IsUp() (up bool, err error) {
+	return false, nil
+}
+
+func (d *deployer) DumpClusterLogs() error {
+	return nil
+}
+
+func (d *deployer) Build() error {
+	// TODO: build should probably still exist with common options
+	return nil
+}
+
+func (d *deployer) Kubeconfig() (string, error) {
+	// noop deployer is specifically used with an existing cluster and KUBECONFIG
+	if d.KubeconfigPath != "" {
+		return d.KubeconfigPath, nil
+	}
+	if kconfig, ok := os.LookupEnv("KUBECONFIG"); ok {
+		return kconfig, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".kube", "config"), nil
+}
+
+// helper used to create & bind a flagset to the deployer
+func bindFlags(d *deployer) *pflag.FlagSet {
+	flags, err := gpflag.Parse(d)
+	if err != nil {
+		klog.Fatalf("unable to generate flags from deployer")
+		return nil
+	}
+
+	klog.InitFlags(nil)
+	flags.AddGoFlagSet(flag.CommandLine)
+
+	return flags
+}
+
+// assert that deployer implements types.DeployerWithKubeconfig
+var _ types.DeployerWithKubeconfig = &deployer{}

--- a/kubetest2-noop/main.go
+++ b/kubetest2-noop/main.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"sigs.k8s.io/kubetest2/pkg/app"
+
+	"sigs.k8s.io/kubetest2/kubetest2-noop/deployer"
+)
+
+func main() {
+	app.Main(deployer.Name, deployer.New)
+}

--- a/kubetest2-tester-node/main.go
+++ b/kubetest2-tester-node/main.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	nodetester "sigs.k8s.io/kubetest2/pkg/testers/node"
+)
+
+func main() {
+	nodetester.Main()
+}

--- a/pkg/testers/node/node.go
+++ b/pkg/testers/node/node.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package node implements a node tester that implements e2e node testing following
+// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/e2e-node-tests.md#delete-instance-after-tests-run
+// https://github.com/kubernetes/kubernetes/blob/96be00df69390ed41b8ec22facc43bcbb9c88aae/build/root/Makefile#L206-L271
+// currently only support REMOTE=true
+package node
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/octago/sflags/gen/gpflag"
+	"k8s.io/klog"
+	"sigs.k8s.io/boskos/client"
+
+	"sigs.k8s.io/kubetest2/pkg/boskos"
+	"sigs.k8s.io/kubetest2/pkg/exec"
+)
+
+const (
+	target                 = "test-e2e-node"
+	gceProjectResourceType = "gce-project"
+)
+
+type Tester struct {
+	RepoRoot                    string `desc:"Absolute path to kubernetes repository root."`
+	GCPProject                  string `desc:"GCP Project to create VMs in. If unset, the deployer will attempt to get a project from boskos."`
+	GCPZone                     string `desc:"GCP Zone to create VMs in."`
+	SkipRegex                   string `desc:"Regular expression of jobs to skip."`
+	FocusRegex                  string `desc:"Regular expression of jobs to focus on."`
+	Runtime                     string `desc:"Container runtime to use."`
+	TestArgs                    string `desc:"A space-separated list of arguments to pass to node e2e test."`
+	BoskosAcquireTimeoutSeconds int    `desc:"How long (in seconds) to hang on a request to Boskos to acquire a resource before erroring."`
+	BoskosLocation              string `desc:"If set, manually specifies the location of the boskos server. If unset and boskos is needed"`
+
+	// boskos struct field will be non-nil when the deployer is
+	// using boskos to acquire a GCP project
+	boskos *client.Client
+
+	// this channel serves as a signal channel for the hearbeat goroutine
+	// so that it can be explicitly closed
+	boskosHeartbeatClose chan struct{}
+}
+
+func NewDefaultTester() *Tester {
+	return &Tester{
+		SkipRegex:                   `\[Flaky\]|\[Slow\]|\[Serial\]`,
+		Runtime:                     "docker",
+		BoskosLocation:              "http://boskos.test-pods.svc.cluster.local.",
+		BoskosAcquireTimeoutSeconds: 5 * 60,
+	}
+}
+
+func (t *Tester) Execute() error {
+	fs, err := gpflag.Parse(t)
+	if err != nil {
+		return fmt.Errorf("failed to initialize tester: %v", err)
+	}
+
+	klog.InitFlags(nil)
+	fs.AddGoFlagSet(flag.CommandLine)
+
+	help := fs.BoolP("help", "h", false, "")
+	if err := fs.Parse(os.Args); err != nil {
+		return fmt.Errorf("failed to parse flags: %v", err)
+	}
+
+	if *help {
+		fs.SetOutput(os.Stdout)
+		fs.PrintDefaults()
+		return nil
+	}
+	if err := t.validateFlags(); err != nil {
+		return fmt.Errorf("failed to validate flags: %v", err)
+	}
+
+	// try to acquire project from boskos
+	if t.GCPProject == "" {
+		klog.V(1).Info("no GCP project provided, acquiring from Boskos ...")
+
+		boskosClient, err := boskos.NewClient(t.BoskosLocation)
+		if err != nil {
+			return fmt.Errorf("failed to make boskos client: %s", err)
+		}
+		t.boskos = boskosClient
+
+		resource, err := boskos.Acquire(
+			t.boskos,
+			gceProjectResourceType,
+			time.Duration(t.BoskosAcquireTimeoutSeconds)*time.Second,
+			t.boskosHeartbeatClose,
+		)
+
+		if err != nil {
+			return fmt.Errorf("init failed to get project from boskos: %s", err)
+		}
+		t.GCPProject = resource.Name
+		klog.V(1).Infof("got project %s from boskos", t.GCPProject)
+	}
+
+	defer func() {
+		if t.boskos != nil {
+			klog.V(1).Info("releasing boskos project")
+			err := boskos.Release(
+				t.boskos,
+				t.GCPProject,
+				t.boskosHeartbeatClose,
+			)
+			if err != nil {
+				klog.Errorf("failed to release boskos project: %v", err)
+			}
+		}
+	}()
+
+	return t.Test()
+}
+
+func (t *Tester) validateFlags() error {
+	if t.RepoRoot == "" {
+		return fmt.Errorf("required --repo-root")
+	}
+	if t.GCPZone == "" {
+		return fmt.Errorf("required --gcp-zone")
+	}
+	return nil
+}
+
+func (t *Tester) constructArgs() []string {
+	defaultArgs := []string{
+		"REMOTE=true",
+		"DELETE_INSTANCES=true",
+	}
+
+	argsFromFlags := []string{
+		"SKIP=" + t.SkipRegex,
+		"FOCUS=" + t.FocusRegex,
+		"RUNTIME=" + t.Runtime,
+		// https://github.com/kubernetes/kubernetes/blob/96be00df69390ed41b8ec22facc43bcbb9c88aae/hack/make-rules/test-e2e-node.sh#L120
+		// TODO: this should be configurable without overriding at the gcloud env level
+		"CLOUDSDK_CORE_PROJECT=" + t.GCPProject,
+		// https://github.com/kubernetes/kubernetes/blob/96be00df69390ed41b8ec22facc43bcbb9c88aae/hack/make-rules/test-e2e-node.sh#L113
+		"ZONE=" + t.GCPZone,
+	}
+	return append(defaultArgs, argsFromFlags...)
+}
+
+func (t *Tester) Test() error {
+	var args []string
+	args = append(args, target)
+	args = append(args, t.constructArgs()...)
+	cmd := exec.Command("make", args...)
+	cmd.SetDir(t.RepoRoot)
+	exec.InheritOutput(cmd)
+	return cmd.Run()
+}
+
+func Main() {
+	t := NewDefaultTester()
+	if err := t.Execute(); err != nil {
+		klog.Fatalf("failed to run ginkgo tester: %v", err)
+	}
+}

--- a/pkg/testers/node/node.go
+++ b/pkg/testers/node/node.go
@@ -40,15 +40,16 @@ const (
 )
 
 type Tester struct {
-	RepoRoot                    string `desc:"Absolute path to kubernetes repository root."`
-	GCPProject                  string `desc:"GCP Project to create VMs in. If unset, the deployer will attempt to get a project from boskos."`
-	GCPZone                     string `desc:"GCP Zone to create VMs in."`
-	SkipRegex                   string `desc:"Regular expression of jobs to skip."`
-	FocusRegex                  string `desc:"Regular expression of jobs to focus on."`
-	Runtime                     string `desc:"Container runtime to use."`
-	TestArgs                    string `desc:"A space-separated list of arguments to pass to node e2e test."`
-	BoskosAcquireTimeoutSeconds int    `desc:"How long (in seconds) to hang on a request to Boskos to acquire a resource before erroring."`
-	BoskosLocation              string `desc:"If set, manually specifies the location of the boskos server. If unset and boskos is needed"`
+	RepoRoot                       string `desc:"Absolute path to kubernetes repository root."`
+	GCPProject                     string `desc:"GCP Project to create VMs in. If unset, the deployer will attempt to get a project from boskos."`
+	GCPZone                        string `desc:"GCP Zone to create VMs in."`
+	SkipRegex                      string `desc:"Regular expression of jobs to skip."`
+	FocusRegex                     string `desc:"Regular expression of jobs to focus on."`
+	Runtime                        string `desc:"Container runtime to use."`
+	TestArgs                       string `desc:"A space-separated list of arguments to pass to node e2e test."`
+	BoskosAcquireTimeoutSeconds    int    `desc:"How long (in seconds) to hang on a request to Boskos to acquire a resource before erroring."`
+	BoskosHeartbeatIntervalSeconds int    `desc:"How often (in seconds) to send a heartbeat to Boskos to hold the acquired resource. 0 means no heartbeat."`
+	BoskosLocation                 string `desc:"If set, manually specifies the location of the boskos server. If unset and boskos is needed"`
 
 	// boskos struct field will be non-nil when the deployer is
 	// using boskos to acquire a GCP project
@@ -105,6 +106,7 @@ func (t *Tester) Execute() error {
 			t.boskos,
 			gceProjectResourceType,
 			time.Duration(t.BoskosAcquireTimeoutSeconds)*time.Second,
+			time.Duration(t.BoskosHeartbeatIntervalSeconds)*time.Second,
 			t.boskosHeartbeatClose,
 		)
 


### PR DESCRIPTION
Also add a noop deployer to go with it.

Started with `REMOTE=true` only since most testing uses that.

fixes: https://github.com/kubernetes-sigs/kubetest2/issues/45

ref:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/e2e-node-tests.md#delete-instance-after-tests-run
ref: https://github.com/kubernetes/kubernetes/blob/96be00df69390ed41b8ec22facc43bcbb9c88aae/build/root/Makefile#L206-L271
ref: https://github.com/kubernetes/kubernetes/blob/master/hack/make-rules/test-e2e-node.sh
xref: https://github.com/kubernetes/enhancements/issues/2464

Currently fully relies on `make test-e2e-node` which itself does a build https://github.com/kubernetes/kubernetes/blob/cea1d4e20b4a7886d8ff65f34c6d4f95efcb4742/test/e2e_node/builder/build.go, 
might be possible to breakout the build part separately into a dedicated node deployer in the future.

Also sadly, local runs don't stream the test logs everything is dumped when the tests finish

tested locally with

```
kubetest2 noop -v2 --test=node -- --repo-root=<repo-root> --gcp-zone=<zone> --gcp-project=<project> -v2 --focus-regex='should.not.show.its.pid.in.the.non-hostpid.containers.\[NodeFeature:HostAccess\]' --test-args='--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"'
```

started with porting over functionality needed by `pull-kubernetes-node-e2e`

/cc @BenTheElder @spiffxp @dims 