### PR TITLE
Add classname attr to the JUnit test case and add a flag to allow skipping test junit report

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -140,9 +140,10 @@ func RealMain(opts types.Options, d types.Deployer, tester types.Tester) (result
 
 		}
 		test.SetEnv(envsForTester...)
-		if err := writer.WrapStep("Test", test.Run); err != nil {
-			return err
+		if !opts.SkipTestJUnitReport() {
+			return writer.WrapStep("Test", test.Run)
 		}
+		return test.Run()
 	}
 
 	return nil

--- a/pkg/app/cmd.go
+++ b/pkg/app/cmd.go
@@ -184,12 +184,13 @@ func splitArgs(args []string) ([]string, []string) {
 
 // options holds flag values and implements deployer.Options
 type options struct {
-	help  bool
-	build bool
-	up    bool
-	down  bool
-	test  string
-	runid string
+	help                bool
+	build               bool
+	up                  bool
+	down                bool
+	test                string
+	skipTestJUnitReport bool
+	runid               string
 }
 
 // bindFlags registers all first class kubetest2 flags
@@ -199,6 +200,8 @@ func (o *options) bindFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&o.up, "up", false, "provision the test cluster")
 	flags.BoolVar(&o.down, "down", false, "tear down the test cluster")
 	flags.StringVar(&o.test, "test", "", "test type to run, if unset no tests will run")
+	flags.BoolVar(&o.skipTestJUnitReport, "skip-test-junit-report", false, "skip reporting the test step as a JUnit test case, "+
+		"should be set to true when solely relying on the tester binary to generate it's own junit.")
 
 	var defaultRunID string
 	// reuse uid for CI use cases
@@ -231,6 +234,10 @@ func (o *options) ShouldDown() bool {
 
 func (o *options) ShouldTest() bool {
 	return o.test != ""
+}
+
+func (o *options) SkipTestJUnitReport() bool {
+	return o.skipTestJUnitReport
 }
 
 func (o *options) RunID() string {

--- a/pkg/metadata/junit.go
+++ b/pkg/metadata/junit.go
@@ -86,6 +86,7 @@ func (t *testSuite) AddTestCase(tc testCase) {
 type testCase struct {
 	XMLName   xml.Name `xml:"testcase"`
 	Name      string   `xml:"name,attr"`
+	ClassName string   `xml:"classname,attr"`
 	Time      float64  `xml:"time,attr"`
 	Failure   string   `xml:"failure,omitempty"`
 	Skipped   string   `xml:"skipped,omitempty"`

--- a/pkg/metadata/writer.go
+++ b/pkg/metadata/writer.go
@@ -44,15 +44,16 @@ func NewWriter(suiteName string, runnerOut io.Writer) *Writer {
 }
 
 // WrapStep executes doStep and captures the output to be written to the
-// kubetest2 runner metadta. if doStep returns a JUnitError this metadata
+// kubetest2 runner metadata. If doStep returns a JUnitError this metadata
 // will be captured
 func (w *Writer) WrapStep(name string, doStep func() error) error {
 	start := w.timeNow()
 	err := doStep()
 	finish := w.timeNow()
 	tc := testCase{
-		Name: name,
-		Time: finish.Sub(start).Seconds(),
+		Name:      name,
+		ClassName: w.suite.Name,
+		Time:      finish.Sub(start).Seconds(),
 	}
 	if err != nil {
 		tc.Failure = err.Error()

--- a/pkg/metadata/writer_test.go
+++ b/pkg/metadata/writer_test.go
@@ -73,7 +73,7 @@ func TestWriter(t *testing.T) {
 			expectedOutput: strings.TrimPrefix(
 				`
 <?xml version="1.0" encoding="UTF-8"?><testsuite name="kubetest2" failures="0" tests="1" time="3">
-    <testcase name="noop" time="1"></testcase>
+    <testcase name="noop" classname="kubetest2" time="1"></testcase>
 </testsuite>`,
 				"\n",
 			),
@@ -90,7 +90,7 @@ func TestWriter(t *testing.T) {
 			expectedOutput: strings.TrimPrefix(
 				`
 <?xml version="1.0" encoding="UTF-8"?><testsuite name="kubetest2" failures="1" tests="1" time="3">
-    <testcase name="always fails" time="1">
+    <testcase name="always fails" classname="kubetest2" time="1">
         <failure>oh noes</failure>
     </testcase>
 </testsuite>`,
@@ -114,7 +114,7 @@ func TestWriter(t *testing.T) {
 			expectedOutput: strings.TrimPrefix(
 				`
 <?xml version="1.0" encoding="UTF-8"?><testsuite name="kubetest2" failures="1" tests="1" time="3">
-    <testcase name="always fails (junitError)" time="1">
+    <testcase name="always fails (junitError)" classname="kubetest2" time="1">
         <failure>on noes</failure>
         <system-out>uh oh</system-out>
     </testcase>
@@ -147,9 +147,9 @@ func TestWriter(t *testing.T) {
 			expectedOutput: strings.TrimPrefix(
 				`
 <?xml version="1.0" encoding="UTF-8"?><testsuite name="kubetest2" failures="1" tests="3" time="7">
-    <testcase name="noop" time="1"></testcase>
-    <testcase name="noop2" time="1"></testcase>
-    <testcase name="always fails (junitError)" time="1">
+    <testcase name="noop" classname="kubetest2" time="1"></testcase>
+    <testcase name="noop2" classname="kubetest2" time="1"></testcase>
+    <testcase name="always fails (junitError)" classname="kubetest2" time="1">
         <failure>on noes</failure>
         <system-out>uh oh</system-out>
     </testcase>

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -54,6 +54,8 @@ type Options interface {
 	ShouldDown() bool
 	// if this is true, kubetest2 will be calling tester.Test
 	ShouldTest() bool
+	// if this is true, kubetest2 will be skipping reporting the test result as a JUnit test case.
+	SkipTestJUnitReport() bool
 	// RunID returns a unique identifier for a kubetest2 run.
 	RunID() string
 	// RunDir returns the directory to put run-specific output files.


### PR DESCRIPTION
1. Add `classname` attribute to the JUnit test case to show on Spyglass, this will fix https://github.com/kubernetes-sigs/kubetest2/issues/107
2. For some tester implementations, they will be generating their own Junit results, in which cases the extra `Test` JUnit result will be redundant. So add an extra flag `--skip-test-junit-report` to allow skipping reporting the JUnit test result. This will partially fix https://github.com/kubernetes-sigs/kubetest2/issues/58.