### PR TITLE
Kubetest2 Version Addition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,9 @@
 # get the repo root and output path
 REPO_ROOT:=$(shell pwd)
 export REPO_ROOT
-OUT_DIR?=$(REPO_ROOT)/bin
+OUT_DIR=$(REPO_ROOT)/bin
+# record the source commit in the binary, overridable
+COMMIT?=$(shell git describe --tags --always --dirty 2>/dev/null)
 INSTALL?=install
 # make install will place binaries here
 # the default path attempts to mimic go install
@@ -47,7 +49,7 @@ SPACE:=$(subst ,, )
 SHELL:=env PATH=$(subst $(SPACE),\$(SPACE),$(PATH)) $(SHELL)
 # ==============================================================================
 # flags for reproducible go builds
-BUILD_FLAGS?=-trimpath -ldflags="-buildid="
+BUILD_FLAGS?=-trimpath -ldflags="-buildid= -X=sigs.k8s.io/kubetest2/pkg/app.GitTag=$(COMMIT)"
 
 build-all:
 	go build -v $(BUILD_FLAGS) ./...

--- a/pkg/app/cmd.go
+++ b/pkg/app/cmd.go
@@ -67,6 +67,8 @@ func runE(
 	opts.bindFlags(kubetest2Flags)
 	artifacts.MustBindFlags(kubetest2Flags)
 
+	cmd.Printf("Running deployer %s version: %s\n", deployerName, shim.GitTag)
+
 	// NOTE: unknown flags are forwarded to the deployer as arguments
 	kubetest2Flags.ParseErrorsWhitelist.UnknownFlags = true
 
@@ -91,6 +93,7 @@ func runE(
 		if err != nil {
 			return fmt.Errorf("unable to find tester %v: %v", opts.test, err)
 		}
+		cmd.Printf("Running tester %s version: %s\n", opts.test, shim.GitTag)
 
 		// Get tester usage by running it with --help
 		var helpArgs []string

--- a/pkg/app/shim/shim.go
+++ b/pkg/app/shim/shim.go
@@ -26,6 +26,9 @@ import (
 	"sigs.k8s.io/kubetest2/pkg/process"
 )
 
+// GitTag captures the git commit SHA of the build. This gets printed by all the deployers and testers
+var GitTag string
+
 // Main implements the kubetest2 root binary entrypoint
 func Main() {
 	if err := Run(); err != nil {
@@ -66,21 +69,28 @@ func NewCommand() *cobra.Command {
 
 // runE implements the actual command logic
 func runE(cmd *cobra.Command, args []string) error {
+	cmd.Printf("Running %s version: %s\n", BinaryName, GitTag)
 	// there should be at least one argument (the deployer) unless the user
 	// is asking for help on the shim itself
 	if len(args) < 1 {
 		return cmd.Help()
 	}
 
-	// gracefully handle -h or --help if it is the only argument
+	// gracefully handle help or version command if it is the only argument
 	if len(args) == 1 {
 		// check for -h, --help
 		flags := pflag.NewFlagSet(BinaryName, pflag.ContinueOnError)
 		help := flags.BoolP("help", "h", false, "")
+		// check for -v, --version
+		ver := flags.BoolP("version", "v", false, fmt.Sprintf("prints %s version", BinaryName))
 		// we don't care about errors, only if -h / --help was set
 		_ = flags.Parse(args)
 		if *help {
 			return cmd.Help()
+		}
+		if *ver {
+			fmt.Printf("%s version %s\n", BinaryName, GitTag)
+			return nil
 		}
 	}
 


### PR DESCRIPTION
- Uses ldflags to capture HEAD rev in short form.
- Prints built commit version by default
- Adds --version support
- Fixes partially #108