### PR TITLE
For private clusters, do not use --create-subnetwork if it's multi-project profile

### DIFF
--- a/kubetest2-gke/deployer/network.go
+++ b/kubetest2-gke/deployer/network.go
@@ -362,19 +362,24 @@ func removeHostServiceAgentUserRole(projects []string) error {
 
 // This function returns the args required for creating a private cluster.
 // Reference: https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#top_of_page
-func privateClusterArgs(network, accessLevel string, masterIPRanges []string, clusterInfo cluster) []string {
+func privateClusterArgs(projects []string, network, accessLevel string, masterIPRanges []string, clusterInfo cluster) []string {
 	if accessLevel == "" {
 		return []string{}
 	}
 
-	subnetName := network + "-" + clusterInfo.name
 	common := []string{
-		"--create-subnetwork=name=" + subnetName,
 		"--enable-ip-alias",
 		"--enable-private-nodes",
 		"--no-enable-basic-auth",
 		"--master-ipv4-cidr=" + masterIPRanges[clusterInfo.index],
 		"--no-issue-client-certificate",
+	}
+
+	// For multi-project profile, it'll be using the shared vpc, which creates subnets before cluster creation.
+	// So only create subnetworks if it's single-project profile.
+	if len(projects) == 1 {
+		subnetName := network + "-" + clusterInfo.name
+		common = append(common, "--create-subnetwork=name="+subnetName)
 	}
 
 	switch accessLevel {

--- a/kubetest2-gke/deployer/up.go
+++ b/kubetest2-gke/deployer/up.go
@@ -70,7 +70,7 @@ func (d *deployer) Up() error {
 		subNetworkArgs := subNetworkArgs(d.projects, d.region, d.network, i)
 		for j := range d.projectClustersLayout[project] {
 			cluster := d.projectClustersLayout[project][j]
-			privateClusterArgs := privateClusterArgs(d.network, d.privateClusterAccessLevel, d.privateClusterMasterIPRanges, cluster)
+			privateClusterArgs := privateClusterArgs(d.projects, d.network, d.privateClusterAccessLevel, d.privateClusterMasterIPRanges, cluster)
 			eg.Go(func() error {
 				// Create the cluster
 				args := make([]string, len(d.createCommand()))


### PR DESCRIPTION
Since for shared-vpc - the network topology we use for multi-project profile, the subnetworks will be created before cluster creation, so for private cluster + shared vpc, if we also specify `--create-subnetwork`, we will get an error which says `Cannot specify both --subnetwork and --create-subnetwork at the same time.`

This PR updates to the logic to only add `--create-subnetwork` if it's single-project profile.