### PR TITLE
Compute repo_root from bash_source instead of git-revparse

### DIFF
--- a/hack/ci/push-binaries/push-binaries.sh
+++ b/hack/ci/push-binaries/push-binaries.sh
@@ -18,9 +18,10 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+# this script is invoked in GCB as the entrypoint
+# avoid prow potentially not being in the right working directory
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." &> /dev/null && pwd -P)"
 cd "${REPO_ROOT}" &> /dev/null
-
 
 # pass through git details from prow / image builder
 if [ -n "${PULL_BASE_SHA:-}" ]; then


### PR DESCRIPTION
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-kubetest2-push-binaries/1376552429604048896

/cc @BenTheElder @spiffxp 