### PR TITLE
Bump GCB timeout

### DIFF
--- a/hack/ci/push-binaries/cloudbuild.yaml
+++ b/hack/ci/push-binaries/cloudbuild.yaml
@@ -9,3 +9,4 @@ steps:
 substitutions:
   _GIT_TAG: '12345'
   _PULL_BASE_SHA: 'invalid'
+timeout: 3600s # 1 hour


### PR DESCRIPTION
Temporarily bump timeout to get a successful run.
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-kubetest2-push-binaries/1376631371933421568

will decrease back once we have a few successful runs.

/cc @BenTheElder 