### PR TITLE
Let CI override $USER

### DIFF
--- a/kubetest2-gce/deployer/common.go
+++ b/kubetest2-gce/deployer/common.go
@@ -107,12 +107,11 @@ func (d *deployer) buildEnv() []string {
 	// which is by default disabled on GCE VMs if USER is root. In order
 	// for the deployer to work without fuss when run as root (like it
 	// does by default in Prow) we can simply change USER to be something
-	// non-root. USER is not always set in a given environment, so the UID
-	// is checked instead for guaranteed correct information.
-	if uid := os.Getuid(); uid == 0 {
-		env = append(env, fmt.Sprintf("USER=%s", "kubetest2"))
+	// non-root.
+	if user, ok := os.LookupEnv("USER"); ok && user != "root" {
+		env = append(env, fmt.Sprintf("USER=%s", user))
 	} else {
-		env = append(env, fmt.Sprintf("USER=%s", os.Getenv("USER")))
+		env = append(env, fmt.Sprintf("USER=%s", "kubetest2"))
 	}
 
 	// kube-up.sh, kube-down.sh etc. use PROJECT as a parameter


### PR DESCRIPTION
/cc @MushuEE @spiffxp 

Currently failing to dump logs
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-gce-conformance-latest-kubetest2/1379089716992806912

ref: https://github.com/kubernetes-sigs/kubetest2/issues/109

Event though uid is actually 0(root) in the container we want to use whatever prow sets as long as it's not root.