### PR TITLE
allow kubetest2 gke accept major.minor cluster version

### DIFF
--- a/kubetest2-gke/deployer/up.go
+++ b/kubetest2-gke/deployer/up.go
@@ -274,7 +274,7 @@ func validateVersion(version string) error {
 	case "latest", "":
 		return nil
 	default:
-		re, err := regexp.Compile(`(\d)\.(\d)+\.(\d)*(.*)`)
+		re, err := regexp.Compile(`(\d)\.(\d)+(\.(\d)*(.*))?`)
 		if err != nil {
 			return err
 		}

--- a/kubetest2-gke/deployer/up_test.go
+++ b/kubetest2-gke/deployer/up_test.go
@@ -21,6 +21,29 @@ import (
 	"testing"
 )
 
+func TestClusterVersion(t *testing.T) {
+	testCases := []struct {
+		version string
+		valid   bool
+	}{
+		{"1.18", true},
+		{"1.18.16", true},
+		{"1.18.16-gke.502", true},
+		{"1", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.version, func(t *testing.T) {
+			err := validateVersion(tc.version)
+			if tc.valid && err != nil {
+				t.Error("unexpected error", err)
+			} else if !tc.valid && err == nil {
+				t.Error("expected error for case", tc.version)
+			}
+		})
+	}
+}
+
 func TestGenerateClusterNames(t *testing.T) {
 	testCases := []struct {
 		name                 string

--- a/kubetest2-gke/deployer/up_test.go
+++ b/kubetest2-gke/deployer/up_test.go
@@ -33,6 +33,7 @@ func TestClusterVersion(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.version, func(t *testing.T) {
 			err := validateVersion(tc.version)
 			if tc.valid && err != nil {


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/kubetest2/issues/130