### PR TITLE
Fixes to subnets creation for GKE multiproject profile.

### DIFF
--- a/kubetest2-gke/deployer/deployer.go
+++ b/kubetest2-gke/deployer/deployer.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/octago/sflags/gen/gpflag"
@@ -201,12 +202,23 @@ func (d *deployer) verifyLocationFlags() error {
 	return nil
 }
 
-// location returns the location flags for gcloud commands.
-func location(region, zone string) string {
+// locationFlag builds the zone/region flag from the provided zone/region
+// used by gcloud commands.
+func locationFlag(region, zone string) string {
 	if zone != "" {
 		return "--zone=" + zone
 	}
 	return "--region=" + region
+}
+
+// regionFromLocation computes the region from the specified zone/region
+// used by some commands (such as subnets), which do not support zones.
+func regionFromLocation(region, zone string) string {
+	r := region
+	if zone != "" {
+		r = zone[0:strings.LastIndex(zone, "-")]
+	}
+	return r
 }
 
 func bindFlags(d *deployer) *pflag.FlagSet {

--- a/kubetest2-gke/deployer/deployer_test.go
+++ b/kubetest2-gke/deployer/deployer_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import "testing"
+
+func TestLocationFlag(t *testing.T) {
+	testCases := []struct {
+		region   string
+		zone     string
+		expected string
+	}{
+		{
+			region:   "us-central1",
+			zone:     "",
+			expected: "--region=us-central1",
+		},
+		{
+			region:   "",
+			zone:     "us-central1-c",
+			expected: "--zone=us-central1-c",
+		},
+	}
+
+	for _, tc := range testCases {
+		got := locationFlag(tc.region, tc.zone)
+		if got != tc.expected {
+			t.Errorf("expected %q but got %q", tc.expected, got)
+		}
+	}
+}
+
+func TestRegionFromLocation(t *testing.T) {
+	testCases := []struct {
+		region   string
+		zone     string
+		expected string
+	}{
+		{
+			region:   "us-central1",
+			zone:     "",
+			expected: "us-central1",
+		},
+		{
+			region:   "",
+			zone:     "us-central1-c",
+			expected: "us-central1",
+		},
+	}
+
+	for _, tc := range testCases {
+		got := regionFromLocation(tc.region, tc.zone)
+		if got != tc.expected {
+			t.Errorf("expected %q but got %q", tc.expected, got)
+		}
+	}
+}

--- a/kubetest2-gke/deployer/down.go
+++ b/kubetest2-gke/deployer/down.go
@@ -29,6 +29,7 @@ func (d *deployer) Down() error {
 	if err := d.init(); err != nil {
 		return err
 	}
+
 	if len(d.projects) > 0 {
 		if err := d.prepareGcpIfNeeded(d.projects[0]); err != nil {
 			return err
@@ -39,7 +40,7 @@ func (d *deployer) Down() error {
 			project := d.projects[i]
 			for j := range d.projectClustersLayout[project] {
 				cluster := d.projectClustersLayout[project][j]
-				loc := location(d.region, d.zone)
+				loc := locationFlag(d.region, d.zone)
 
 				wg.Add(1)
 				go func() {
@@ -66,10 +67,14 @@ func (d *deployer) Down() error {
 		if err := d.teardownNetwork(); err != nil {
 			return err
 		}
+		if err := d.deleteSubnets(); err != nil {
+			return err
+		}
 		if err := d.deleteNetwork(); err != nil {
 			return err
 		}
 	}
+
 	return nil
 }
 

--- a/kubetest2-gke/deployer/firewall.go
+++ b/kubetest2-gke/deployer/firewall.go
@@ -46,7 +46,7 @@ func ensureFirewallRulesForSingleProject(project, network string, clusters []clu
 	for _, cluster := range clusters {
 		clusterName := cluster.name
 		klog.V(1).Infof("Ensuring firewall rules for cluster %s in %s", clusterName, project)
-		firewall := getClusterFirewall(project, clusterName, instanceGroups)
+		firewall := clusterFirewallName(project, clusterName, instanceGroups)
 		if runWithNoOutput(exec.Command("gcloud", "compute", "firewall-rules", "describe", firewall,
 			"--project="+project,
 			"--format=value(name)")) == nil {
@@ -79,7 +79,7 @@ func ensureFirewallRulesForSingleProject(project, network string, clusters []clu
 	return nil
 }
 
-func getClusterFirewall(project, cluster string, instanceGroups map[string]map[string][]*ig) string {
+func clusterFirewallName(project, cluster string, instanceGroups map[string]map[string][]*ig) string {
 	// We want to ensure that there's an e2e-ports-* firewall rule
 	// that maps to the cluster nodes, but the target tag for the
 	// nodes can be slow to get. Use the hash from the lexically first
@@ -159,7 +159,7 @@ func (d *deployer) getInstanceGroups() error {
 	// Initialize project instance groups structure
 	d.instanceGroups = map[string]map[string][]*ig{}
 
-	location := location(d.region, d.zone)
+	location := locationFlag(d.region, d.zone)
 
 	for _, project := range d.projects {
 		d.instanceGroups[project] = map[string][]*ig{}


### PR DESCRIPTION
1. subnet create command does not support --zone(https://cloud.google.com/sdk/gcloud/reference/compute/networks/subnets/create) but cluster create command supports, this PR converts zone to region when creating subnets if zonal clusters are requested.
2. Move createSubnets and deleteSubnets to separate functions.