### PR TITLE
Kubetest2 gke retry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/octago/sflags v0.2.0
 	github.com/pkg/errors v0.9.1
+	github.com/pkg/math v0.0.0-20141027224758-f2ed9e40e245
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a

--- a/go.sum
+++ b/go.sum
@@ -858,6 +858,8 @@ github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/math v0.0.0-20141027224758-f2ed9e40e245 h1:gk/AF9SGRj+RafNCoDcS3RRscb8S4BVbvqODOgWA7/8=
+github.com/pkg/math v0.0.0-20141027224758-f2ed9e40e245/go.mod h1:2dhPPj2Li3DXrSY2U2ADdZy2B7sjQsT57lqENx1+FSE=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/kubetest2-gke/deployer/common.go
+++ b/kubetest2-gke/deployer/common.go
@@ -18,7 +18,7 @@ package deployer
 
 import (
 	"fmt"
-	realexec "os/exec"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -26,7 +26,6 @@ import (
 	"k8s.io/klog"
 
 	"sigs.k8s.io/kubetest2/pkg/boskos"
-	"sigs.k8s.io/kubetest2/pkg/exec"
 )
 
 const (
@@ -45,6 +44,16 @@ func (d *deployer) initialize() error {
 	if d.commonOptions.ShouldUp() {
 		if err := d.verifyUpFlags(); err != nil {
 			return fmt.Errorf("init failed to verify flags for up: %w", err)
+		}
+
+		// Compile the retryable error patterns as regex objects.
+		d.retryableErrorPatternsCompiled = make([]*regexp.Regexp, len(d.retryableErrorPatterns))
+		for i, regxString := range d.retryableErrorPatterns {
+			var err error
+			d.retryableErrorPatternsCompiled[i], err = regexp.Compile(regxString)
+			if err != nil {
+				return fmt.Errorf("error compiling regex: %w", err)
+			}
 		}
 
 		if len(d.projects) == 0 {
@@ -115,27 +124,4 @@ func buildProjectClustersLayout(projects, clusters []string, projectClustersLayo
 		projectClustersLayout[projects[projectIndex]] = append(projectClustersLayout[projects[projectIndex]], cluster{i, parts[0]})
 	}
 	return nil
-}
-
-func containerArgs(args ...string) []string {
-	return append(append([]string{}, "container"), args...)
-}
-
-func runWithNoOutput(cmd exec.Cmd) error {
-	exec.NoOutput(cmd)
-	return cmd.Run()
-}
-
-func runWithOutput(cmd exec.Cmd) error {
-	exec.InheritOutput(cmd)
-	return cmd.Run()
-}
-
-// execError returns a string format of err including stderr if the
-// err is an ExitError, useful for errors from e.g. exec.Cmd.Output().
-func execError(err error) string {
-	if ee, ok := err.(*realexec.ExitError); ok {
-		return fmt.Sprintf("%v (output: %q)", err, string(ee.Stderr))
-	}
-	return err.Error()
 }

--- a/kubetest2-gke/deployer/deployer_test.go
+++ b/kubetest2-gke/deployer/deployer_test.go
@@ -20,24 +20,33 @@ import "testing"
 
 func TestLocationFlag(t *testing.T) {
 	testCases := []struct {
-		region   string
-		zone     string
-		expected string
+		regions    []string
+		zones      []string
+		retryCount int
+		expected   string
 	}{
 		{
-			region:   "us-central1",
-			zone:     "",
-			expected: "--region=us-central1",
+			regions:    []string{"us-central1"},
+			zones:      []string{},
+			retryCount: 0,
+			expected:   "--region=us-central1",
 		},
 		{
-			region:   "",
-			zone:     "us-central1-c",
-			expected: "--zone=us-central1-c",
+			regions:    []string{},
+			zones:      []string{"us-central1-c"},
+			retryCount: 0,
+			expected:   "--zone=us-central1-c",
+		},
+		{
+			regions:    []string{"us-central1", "us-east"},
+			zones:      []string{},
+			retryCount: 1,
+			expected:   "--region=us-east",
 		},
 	}
 
 	for _, tc := range testCases {
-		got := locationFlag(tc.region, tc.zone)
+		got := locationFlag(tc.regions, tc.zones, tc.retryCount)
 		if got != tc.expected {
 			t.Errorf("expected %q but got %q", tc.expected, got)
 		}
@@ -46,24 +55,33 @@ func TestLocationFlag(t *testing.T) {
 
 func TestRegionFromLocation(t *testing.T) {
 	testCases := []struct {
-		region   string
-		zone     string
-		expected string
+		regions    []string
+		zones      []string
+		retryCount int
+		expected   string
 	}{
 		{
-			region:   "us-central1",
-			zone:     "",
-			expected: "us-central1",
+			regions:    []string{"us-central1"},
+			zones:      []string{},
+			retryCount: 0,
+			expected:   "us-central1",
 		},
 		{
-			region:   "",
-			zone:     "us-central1-c",
-			expected: "us-central1",
+			regions:    []string{},
+			zones:      []string{"us-central1-c"},
+			retryCount: 0,
+			expected:   "us-central1",
+		},
+		{
+			regions:    []string{"us-central1", "us-east"},
+			zones:      []string{},
+			retryCount: 1,
+			expected:   "us-east",
 		},
 	}
 
 	for _, tc := range testCases {
-		got := regionFromLocation(tc.region, tc.zone)
+		got := regionFromLocation(tc.regions, tc.zones, tc.retryCount)
 		if got != tc.expected {
 			t.Errorf("expected %q but got %q", tc.expected, got)
 		}

--- a/kubetest2-gke/deployer/down.go
+++ b/kubetest2-gke/deployer/down.go
@@ -35,27 +35,7 @@ func (d *deployer) Down() error {
 			return err
 		}
 
-		var wg sync.WaitGroup
-		for i := range d.projects {
-			project := d.projects[i]
-			for j := range d.projectClustersLayout[project] {
-				cluster := d.projectClustersLayout[project][j]
-				loc := locationFlag(d.region, d.zone)
-
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-					// We best-effort try all of these and report errors as appropriate.
-					if err := runWithOutput(exec.Command(
-						"gcloud", containerArgs("clusters", "delete", "-q", cluster.name,
-							"--project="+project,
-							loc)...)); err != nil {
-						klog.Errorf("Error deleting cluster: %v", err)
-					}
-				}()
-			}
-		}
-		wg.Wait()
+		d.deleteClusters(d.retryCount)
 
 		numDeletedFWRules, errCleanFirewalls := d.cleanupNetworkFirewalls(d.projects[0], d.network)
 		if errCleanFirewalls != nil {
@@ -67,7 +47,7 @@ func (d *deployer) Down() error {
 		if err := d.teardownNetwork(); err != nil {
 			return err
 		}
-		if err := d.deleteSubnets(); err != nil {
+		if err := d.deleteSubnets(d.retryCount); err != nil {
 			return err
 		}
 		if err := d.deleteNetwork(); err != nil {
@@ -76,6 +56,34 @@ func (d *deployer) Down() error {
 	}
 
 	return nil
+}
+
+func (d *deployer) deleteClusters(retryCount int) {
+	// We best-effort try all of these and report errors as appropriate.
+	var wg sync.WaitGroup
+	for i := range d.projects {
+		project := d.projects[i]
+		for j := range d.projectClustersLayout[project] {
+			cluster := d.projectClustersLayout[project][j]
+			loc := locationFlag(d.regions, d.zones, retryCount)
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				d.deleteCluster(project, loc, cluster)
+			}()
+		}
+	}
+	wg.Wait()
+}
+
+func (d *deployer) deleteCluster(project, loc string, cluster cluster) {
+	if err := runWithOutput(exec.Command(
+		"gcloud", containerArgs("clusters", "delete", "-q", cluster.name,
+			"--project="+project,
+			loc)...)); err != nil {
+		klog.Errorf("Error deleting cluster: %v", err)
+	}
 }
 
 // verifyDownFlags validates flags for down phase.

--- a/kubetest2-gke/deployer/dumplogs.go
+++ b/kubetest2-gke/deployer/dumplogs.go
@@ -79,7 +79,7 @@ export KUBE_NODE_OS_DISTRIBUTION='%[3]s'
 
 		cmd := exec.Command("bash", "-c", fmt.Sprintf(gkeLogDumpTemplate,
 			project,
-			d.zone,
+			d.zones,
 			os.Getenv("NODE_OS_DISTRIBUTION"),
 			strings.Join(filters, " OR "),
 			dumpCmd))

--- a/kubetest2-gke/deployer/firewall.go
+++ b/kubetest2-gke/deployer/firewall.go
@@ -159,7 +159,7 @@ func (d *deployer) getInstanceGroups() error {
 	// Initialize project instance groups structure
 	d.instanceGroups = map[string]map[string][]*ig{}
 
-	location := locationFlag(d.region, d.zone)
+	location := locationFlag(d.regions, d.zones, d.retryCount)
 
 	for _, project := range d.projects {
 		d.instanceGroups[project] = map[string][]*ig{}

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -116,6 +116,12 @@ func CombinedOutputLines(cmd Cmd) (lines []string, err error) {
 	return lines, err
 }
 
+// SetOutput sets cmd's output to write to the given Writer.
+func SetOutput(cmd Cmd, stdoutWriter, stderrWriter io.Writer) {
+	cmd.SetStdout(stdoutWriter)
+	cmd.SetStderr(stderrWriter)
+}
+
 // InheritOutput sets cmd's output to write to the current process's stdout and stderr
 func InheritOutput(cmd Cmd) {
 	cmd.SetStderr(os.Stderr)


### PR DESCRIPTION
This PR adds retries for cluster creation failures. Retry logic includes deleting clusters and subnets before recreating them. Future improvements will include ensuring subnets do not overlap.