### PR TITLE
Change the functions for kubetest2-gke deployer to public

### DIFF
--- a/kubetest2-gke/deployer/build.go
+++ b/kubetest2-gke/deployer/build.go
@@ -46,7 +46,7 @@ var (
 	defaultImageTag = "gke.gcr.io"
 )
 
-func (d *deployer) Build() error {
+func (d *Deployer) Build() error {
 	imageTag := defaultImageTag
 	if d.BuildOptions.CommonBuildOptions.ImageLocation != "" {
 		imageTag = d.BuildOptions.CommonBuildOptions.ImageLocation
@@ -56,7 +56,7 @@ func (d *deployer) Build() error {
 	if err := os.Setenv("KUBE_DOCKER_REGISTRY", imageTag); err != nil {
 		return err
 	}
-	if err := d.verifyBuildFlags(); err != nil {
+	if err := d.VerifyBuildFlags(); err != nil {
 		return err
 	}
 	version, err := d.BuildOptions.Build()
@@ -72,11 +72,11 @@ func (d *deployer) Build() error {
 	// append the kubetest2 run id
 	// avoid double + in the version
 	// so they are valid docker tags
-	if !strings.HasSuffix(version, d.commonOptions.RunID()) {
+	if !strings.HasSuffix(version, d.kubetest2CommonOptions.RunID()) {
 		if strings.Contains(version, "+") {
-			version += "-" + d.commonOptions.RunID()
+			version += "-" + d.kubetest2CommonOptions.RunID()
 		} else {
-			version += "+" + d.commonOptions.RunID()
+			version += "+" + d.kubetest2CommonOptions.RunID()
 		}
 	}
 
@@ -87,22 +87,22 @@ func (d *deployer) Build() error {
 		}
 	}
 	d.Version = version
-	build.StoreCommonBinaries(d.RepoRoot, d.commonOptions.RunDir())
+	build.StoreCommonBinaries(d.RepoRoot, d.kubetest2CommonOptions.RunDir())
 	return nil
 }
 
-func (d *deployer) verifyBuildFlags() error {
+func (d *Deployer) VerifyBuildFlags() error {
 	if d.RepoRoot == "" {
 		return fmt.Errorf("required repo-root when building from source")
 	}
 	d.BuildOptions.CommonBuildOptions.RepoRoot = d.RepoRoot
-	if d.commonOptions.ShouldBuild() && d.commonOptions.ShouldUp() && d.BuildOptions.CommonBuildOptions.StageLocation == "" {
+	if d.kubetest2CommonOptions.ShouldBuild() && d.kubetest2CommonOptions.ShouldUp() && d.BuildOptions.CommonBuildOptions.StageLocation == "" {
 		return fmt.Errorf("creating a gke cluster from built sources requires staging them to a specific GCS bucket, use --stage=gs://<bucket>")
 	}
 	// force extra GCP files to be staged
 	d.BuildOptions.CommonBuildOptions.StageExtraGCPFiles = true
 	// add kubetest2 runid as the version suffix
-	d.BuildOptions.CommonBuildOptions.VersionSuffix = d.commonOptions.RunID()
+	d.BuildOptions.CommonBuildOptions.VersionSuffix = d.kubetest2CommonOptions.RunID()
 	return d.BuildOptions.Validate()
 }
 

--- a/kubetest2-gke/deployer/commandutils.go
+++ b/kubetest2-gke/deployer/commandutils.go
@@ -32,12 +32,12 @@ import (
 	"sigs.k8s.io/kubetest2/pkg/exec"
 )
 
-func (d *deployer) prepareGcpIfNeeded(projectID string) error {
+func (d *Deployer) PrepareGcpIfNeeded(projectID string) error {
 	// TODO(RonWeber): This is an almost direct copy/paste from kubetest's prepareGcp()
 	// It badly needs refactored.
 
 	var endpoint string
-	switch env := d.environment; {
+	switch env := d.Environment; {
 	case env == "test":
 		endpoint = "https://test-container.sandbox.googleapis.com/"
 	case env == "staging":
@@ -64,11 +64,11 @@ func (d *deployer) prepareGcpIfNeeded(projectID string) error {
 	}
 
 	// gcloud creds may have changed
-	if err := activateServiceAccount(d.gcpServiceAccount); err != nil {
+	if err := activateServiceAccount(d.GCPServiceAccount); err != nil {
 		return err
 	}
 
-	if !d.gcpSSHKeyIgnored {
+	if !d.GCPSSHKeyIgnored {
 		// Ensure ssh keys exist
 		klog.V(1).Info("Checking existing of GCP ssh keys...")
 		k := filepath.Join(home(".ssh"), "google_compute_engine")

--- a/kubetest2-gke/deployer/deployer.go
+++ b/kubetest2-gke/deployer/deployer.go
@@ -90,67 +90,30 @@ type cluster struct {
 	name  string
 }
 
-type deployer struct {
+type Deployer struct {
 	// generic parts
-	commonOptions types.Options
+	kubetest2CommonOptions types.Options
 
-	BuildOptions *options.BuildOptions
-	UpOptions    *options.UpOptions
-
-	RepoRoot       string `desc:"Path to root of the kubernetes repo. Used with --build and for dumping cluster logs."`
-	ReleaseChannel string `desc:"Use a GKE release channel, could be one of empty, rapid, regular and stable - https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels"`
-	Version        string `desc:"Use a specific GKE version e.g. 1.16.13.gke-400, 'latest' or ''. If --build is specified it will default to building kubernetes from source."`
+	*options.BuildOptions
+	*options.CommonOptions
+	*options.UpOptions
 
 	// doInit helps to make sure the initialization is performed only once
 	doInit sync.Once
-	// gke specific details
-	projects                       []string
-	zones                          []string
-	regions                        []string
-	retryCount                     int
-	retryableErrorPatterns         []string
-	retryableErrorPatternsCompiled []*regexp.Regexp
-	clusters                       []string
 	// only used for multi-project multi-cluster profile to save the project-clusters mapping
 	projectClustersLayout map[string][]cluster
-	nodes                 int
-	machineType           string
-	imageType             string
-	network               string
-	subnetworkRanges      []string
-	environment           string
-	gcpServiceAccount     string
-
-	gcloudCommandGroup string
-	autopilot          bool
-	gcloudExtraFlags   string
-	createCommandFlag  string
+	// project -> cluster -> instance groups
+	instanceGroups map[string]map[string][]*ig
 
 	kubecfgPath  string
 	testPrepared bool
-	// project -> cluster -> instance groups
-	instanceGroups map[string]map[string][]*ig
 
 	localLogsDir string
 	gcsLogsDir   string
 
-	// whether the GCP SSH key is required or not
-	gcpSSHKeyIgnored bool
-
-	// Enable workload identity or not.
-	// See the details in https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
-	workloadIdentityEnabled bool
-
-	// Private cluster access level, must be one of "no", "limited" and "unrestricted".
-	// See the details in https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters
-	privateClusterAccessLevel    string
-	privateClusterMasterIPRanges []string
-
-	boskosLocation              string
-	boskosResourceType          string
-	boskosAcquireTimeoutSeconds int
-	// number of boskos projects to request if `projects` is empty
-	boskosProjectsRequested int
+	// gke specific details
+	retryCount                     int
+	retryableErrorPatternsCompiled []*regexp.Regexp
 
 	// boskos struct field will be non-nil when the deployer is
 	// using boskos to acquire a GCP project
@@ -165,17 +128,17 @@ type deployer struct {
 var _ types.NewDeployer = New
 
 // assert that deployer implements types.Deployer
-var _ types.Deployer = &deployer{}
+var _ types.Deployer = &Deployer{}
 
-func (d *deployer) Provider() string {
+func (d *Deployer) Provider() string {
 	return Name
 }
 
 // New implements deployer.New for gke
 func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 	// create a deployer object and set fields that are not flag controlled
-	d := &deployer{
-		commonOptions: opts,
+	d := &Deployer{
+		kubetest2CommonOptions: opts,
 		BuildOptions: &options.BuildOptions{
 			CommonBuildOptions: &build.Options{
 				Builder:  &build.NoopBuilder{},
@@ -183,12 +146,27 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 				Strategy: "make",
 			},
 		},
+		CommonOptions: &options.CommonOptions{
+			Network:     "default",
+			Environment: "prod",
+		},
 		UpOptions: &options.UpOptions{
 			NumClusters: 1,
+			NumNodes:    defaultNodePool.Nodes,
+			MachineType: defaultNodePool.MachineType,
+			ImageType:   defaultImage,
+			// Leave Version as empty to use the default cluster version.
+			Version:          "",
+			GCPSSHKeyIgnored: true,
+
+			BoskosLocation:              defaultBoskosLocation,
+			BoskosResourceType:          defaultGKEProjectResourceType,
+			BoskosAcquireTimeoutSeconds: defaultBoskosAcquireTimeoutSeconds,
+			BoskosProjectsRequested:     1,
+
+			RetryableErrorPatterns: []string{gceStockoutErrorPattern},
 		},
 		localLogsDir: filepath.Join(opts.RunDir(), "logs"),
-		// Leave Version as empty to use the default cluster version.
-		Version: "",
 	}
 
 	// register flags
@@ -200,10 +178,10 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 	return d, fs
 }
 
-func (d *deployer) verifyLocationFlags() error {
-	if len(d.zones) == 0 && len(d.regions) == 0 {
+func (d *Deployer) VerifyLocationFlags() error {
+	if len(d.Zones) == 0 && len(d.Regions) == 0 {
 		return fmt.Errorf("--zone or --region must be set for GKE deployment")
-	} else if len(d.zones) != 0 && len(d.regions) != 0 {
+	} else if len(d.Zones) != 0 && len(d.Regions) != 0 {
 		return fmt.Errorf("--zone and --region cannot both be set")
 	}
 	return nil
@@ -228,41 +206,12 @@ func regionFromLocation(regions, zones []string, retryCount int) string {
 	return regions[retryCount]
 }
 
-func bindFlags(d *deployer) *pflag.FlagSet {
+func bindFlags(d *Deployer) *pflag.FlagSet {
 	flags, err := gpflag.Parse(d)
 	if err != nil {
 		klog.Fatalf("unable to generate flags from deployer")
 		return nil
 	}
-
-	flags.StringVar(&d.gcloudCommandGroup, "gcloud-command-group", "", "gcloud command group, can be one of empty, alpha, beta")
-	flags.BoolVar(&d.autopilot, "autopilot", false, "Whether to create GKE Autopilot clusters or not")
-	flags.StringVar(&d.gcloudExtraFlags, "gcloud-extra-flags", "", "Extra gcloud flags to pass when creating the clusters")
-	flags.StringVar(&d.createCommandFlag, "create-command", "", "gcloud subcommand and additional flags used to create a cluster, such as `container clusters create --quiet`."+
-		"If it's specified, --gcloud-command-group, --autopilot, --gcloud-extra-flags will be ignored.")
-	flags.StringSliceVar(&d.clusters, "cluster-name", []string{}, "Cluster names separated by comma. Must be set. "+
-		"For multi-project profile, it should be in the format of clusterA:0,clusterB:1,clusterC:2, where the index means the index of the project.")
-	flags.StringVar(&d.gcpServiceAccount, "gcp-service-account", "", "Service account to activate before using gcloud")
-	flags.StringVar(&d.network, "network", "default", "Cluster network. Defaults to the default network if not provided. For multi-project use cases, this will be the Shared VPC network name.")
-	flags.StringSliceVar(&d.subnetworkRanges, "subnetwork-ranges", []string{}, "Subnetwork ranges as required for shared VPC setup as described in https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc#creating_a_network_and_two_subnets."+
-		"For multi-project profile, it is required and should be in the format of `10.0.4.0/22 10.0.32.0/20 10.4.0.0/14,172.16.4.0/22 172.16.16.0/20 172.16.4.0/22`, where the subnetworks configuration for different project"+
-		"are separated by comma, and the ranges of each subnetwork configuration is separated by space.")
-	flags.StringVar(&d.environment, "environment", "prod", "Container API endpoint to use, one of 'test', 'staging', 'prod', or a custom https:// URL. Defaults to prod if not provided")
-	flags.StringSliceVar(&d.projects, "project", []string{}, "Comma separated list of GCP Project(s) to use for creating the cluster.")
-	flags.StringSliceVar(&d.regions, "region", []string{}, "Comma separated list for use with gcloud commands to specify the cluster region(s). The first region will be considered the primary region, and the rest will be considered the backup regions.")
-	flags.StringSliceVar(&d.zones, "zone", []string{}, "Comma separated list for use with gcloud commands to specify the cluster zone(s). The first zone will be considered the primary zone, and the rest will be considered the backup zones.")
-	flags.StringSliceVar(&d.retryableErrorPatterns, "retryable-error-patterns", []string{gceStockoutErrorPattern}, "Comma separated list of regex match patterns for retryable errors during cluster creation.")
-	flags.IntVar(&d.nodes, "num-nodes", defaultNodePool.Nodes, "For use with gcloud commands to specify the number of nodes for the cluster.")
-	flags.StringVar(&d.machineType, "machine-type", defaultNodePool.MachineType, "For use with gcloud commands to specify the machine type for the cluster.")
-	flags.StringVar(&d.imageType, "image-type", defaultImage, "The image type to use for the cluster.")
-	flags.BoolVar(&d.gcpSSHKeyIgnored, "ignore-gcp-ssh-key", true, "Whether the GCP SSH key should be ignored or not for bringing up the cluster.")
-	flags.BoolVar(&d.workloadIdentityEnabled, "enable-workload-identity", false, "Whether enable workload identity for the cluster or not.")
-	flags.StringVar(&d.privateClusterAccessLevel, "private-cluster-access-level", "", "Private cluster access level, if not empty, must be one of 'no', 'limited' or 'unrestricted'")
-	flags.StringSliceVar(&d.privateClusterMasterIPRanges, "private-cluster-master-ip-range", []string{"172.16.0.32/28"}, "Private cluster master IP ranges. It should be IPv4 CIDR(s), and its length must be the same as the number of clusters if private cluster is requested.")
-	flags.StringVar(&d.boskosLocation, "boskos-location", defaultBoskosLocation, "If set, manually specifies the location of the Boskos server")
-	flags.StringVar(&d.boskosResourceType, "boskos-resource-type", defaultGKEProjectResourceType, "If set, manually specifies the resource type of GCP projects to acquire from Boskos")
-	flags.IntVar(&d.boskosAcquireTimeoutSeconds, "boskos-acquire-timeout-seconds", 300, "How long (in seconds) to hang on a request to Boskos to acquire a resource before erroring")
-	flags.IntVar(&d.boskosProjectsRequested, "projects-requested", 1, "Number of projects to request from Boskos. It is only respected if projects is empty, and must be larger than zero ")
 
 	return flags
 }

--- a/kubetest2-gke/deployer/firewall.go
+++ b/kubetest2-gke/deployer/firewall.go
@@ -27,18 +27,18 @@ import (
 	"sigs.k8s.io/kubetest2/pkg/exec"
 )
 
-func (d *deployer) ensureFirewallRules() error {
+func (d *Deployer) EnsureFirewallRules() error {
 	// Do not modify the firewall rules for the default network
-	if d.network == "default" {
+	if d.Network == "default" {
 		return nil
 	}
 
-	if len(d.projects) == 1 {
-		project := d.projects[0]
-		return ensureFirewallRulesForSingleProject(project, d.network, d.projectClustersLayout[project], d.instanceGroups)
+	if len(d.Projects) == 1 {
+		project := d.Projects[0]
+		return ensureFirewallRulesForSingleProject(project, d.Network, d.projectClustersLayout[project], d.instanceGroups)
 	}
 
-	return ensureFirewallRulesForMultiProjects(d.projects, d.network, d.subnetworkRanges)
+	return ensureFirewallRulesForMultiProjects(d.Projects, d.Network, d.SubnetworkRanges)
 }
 
 // Ensure firewall rules for e2e testing for all clusters in one single project.
@@ -118,7 +118,7 @@ func ensureFirewallRulesForMultiProjects(projects []string, network string, subn
 }
 
 // Ensure that all firewall-rules are deleted from specific network.
-func (d *deployer) cleanupNetworkFirewalls(hostProject, network string) (int, error) {
+func (d *Deployer) CleanupNetworkFirewalls(hostProject, network string) (int, error) {
 	// Do not delete firewall rules for the default network.
 	if network == "default" {
 		return 0, nil
@@ -150,7 +150,7 @@ func (d *deployer) cleanupNetworkFirewalls(hostProject, network string) (int, er
 	return len(fws), nil
 }
 
-func (d *deployer) getInstanceGroups() error {
+func (d *Deployer) GetInstanceGroups() error {
 	// If instanceGroups has already been populated, return directly.
 	if d.instanceGroups != nil {
 		return nil
@@ -159,9 +159,9 @@ func (d *deployer) getInstanceGroups() error {
 	// Initialize project instance groups structure
 	d.instanceGroups = map[string]map[string][]*ig{}
 
-	location := locationFlag(d.regions, d.zones, d.retryCount)
+	location := locationFlag(d.Regions, d.Zones, d.retryCount)
 
-	for _, project := range d.projects {
+	for _, project := range d.Projects {
 		d.instanceGroups[project] = map[string][]*ig{}
 
 		for _, cluster := range d.projectClustersLayout[project] {

--- a/kubetest2-gke/deployer/options/common.go
+++ b/kubetest2-gke/deployer/options/common.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+type CommonOptions struct {
+	RepoRoot string `desc:"Path to root of the kubernetes repo. Used with --build and for dumping cluster logs."`
+
+	Environment       string   `flag:"~environment" desc:"Container API endpoint to use, one of 'test', 'staging', 'prod', or a custom https:// URL. Defaults to prod if not provided"`
+	Projects          []string `flag:"~project" desc:"Comma separated list of GCP Project(s) to use for creating the cluster."`
+	Clusters          []string `flag:"~cluster-name" desc:"Cluster names separated by comma. Must be set. For multi-project profile, it should be in the format of clusterA:0,clusterB:1,clusterC:2, where the index means the index of the project."`
+	Regions           []string `flag:"~region" desc:"Comma separated list for use with gcloud commands to specify the cluster region(s). The first region will be considered the primary region, and the rest will be considered the backup regions."`
+	Zones             []string `flag:"~zone" desc:"Comma separated list for use with gcloud commands to specify the cluster zone(s). The first zone will be considered the primary zone, and the rest will be considered the backup zones."`
+	Network           string   `flag:"~network" desc:"Cluster network. Defaults to the default network if not provided. For multi-project use cases, this will be the Shared VPC network name."`
+	GCPServiceAccount string   `flag:"~gcp-service-account" desc:"Service account to activate before using gcloud."`
+}

--- a/kubetest2-gke/deployer/options/up.go
+++ b/kubetest2-gke/deployer/options/up.go
@@ -19,7 +19,30 @@ package options
 import "fmt"
 
 type UpOptions struct {
-	NumClusters int `flag:"~num-clusters" desc:"Number of clusters to create, will auto-generate names as (kt2-<run-id>-<index>)"`
+	GcloudCommandGroup string `flag:"~gcloud-command-group" desc:"gcloud command group, can be one of empty, alpha, beta."`
+	Autopilot          bool   `flag:"~autopilot" desc:"Whether to create GKE Autopilot clusters or not."`
+	GcloudExtraFlags   string `flag:"~gcloud-extra-flags" desc:"Extra gcloud flags to pass when creating the clusters."`
+	CreateCommandFlag  string `flag:"~create-command" desc:"gcloud subcommand and additional flags used to create a cluster, such as container clusters create --quiet. If it's specified, --gcloud-command-group, --autopilot, --gcloud-extra-flags will be ignored."`
+
+	NumClusters             int    `flag:"~num-clusters" desc:"Number of clusters to create, will auto-generate names as (kt2-<run-id>-<index>)."`
+	MachineType             string `flag:"~machine-type" desc:"For use with gcloud commands to specify the machine type for the cluster."`
+	NumNodes                int    `flag:"~num-nodes" desc:"For use with gcloud commands to specify the number of nodes for the cluster."`
+	ImageType               string `flag:"~image-type" desc:"The image type to use for the cluster."`
+	ReleaseChannel          string `desc:"Use a GKE release channel, could be one of empty, rapid, regular and stable - https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels"`
+	Version                 string `desc:"Use a specific GKE version e.g. 1.16.13.gke-400, 'latest' or ''. If --build is specified it will default to building kubernetes from source."`
+	WorkloadIdentityEnabled bool   `flag:"~enable-workload-identity" desc:"Whether enable workload identity for the cluster or not. See the details in https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity."`
+	GCPSSHKeyIgnored        bool   `flag:"~ignore-gcp-ssh-key" desc:"Whether the GCP SSH key should be ignored or not for bringing up the cluster."`
+
+	BoskosLocation              string `flag:"~boskos-location" desc:"If set, manually specifies the location of the Boskos server."`
+	BoskosResourceType          string `flag:"~boskos-resource-type" desc:"If set, manually specifies the resource type of GCP projects to acquire from Boskos."`
+	BoskosAcquireTimeoutSeconds int    `flag:"~boskos-acquire-timeout-seconds" desc:"How long (in seconds) to hang on a request to Boskos to acquire a resource before erroring."`
+	BoskosProjectsRequested     int    `flag:"~projects-requested" desc:"Number of projects to request from Boskos. It is only respected if projects is empty, and must be larger than zero."`
+
+	PrivateClusterAccessLevel    string   `flag:"~private-cluster-access-level" desc:"Private cluster access level, if not empty, must be one of 'no', 'limited' or 'unrestricted'. See the details in https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters."`
+	PrivateClusterMasterIPRanges []string `flag:"~private-cluster-master-ip-range" desc:"Private cluster master IP ranges. It should be IPv4 CIDR(s), and its length must be the same as the number of clusters if private cluster is requested."`
+	SubnetworkRanges             []string `flag:"~subnetwork-ranges" desc:"Subnetwork ranges as required for shared VPC setup as described in https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc#creating_a_network_and_two_subnets. For multi-project profile, it is required and should be in the format of 10.0.4.0/22 10.0.32.0/20 10.4.0.0/14,172.16.4.0/22 172.16.16.0/20 172.16.4.0/22, where the subnetworks configuration for different project are separated by comma, and the ranges of each subnetwork configuration is separated by space."`
+
+	RetryableErrorPatterns []string `flag:"~retryable-error-patterns" desc:"Comma separated list of regex match patterns for retryable errors during cluster creation."`
 }
 
 func (uo *UpOptions) Validate() error {


### PR DESCRIPTION
Change the functions for kubetest2-gke deployer to public, so that it can be used as a library.