### PR TITLE
kubetest2 gke deployer supports retries with different subnet ranges to avoid conflicts

### DIFF
--- a/kubetest2-gke/deployer/common.go
+++ b/kubetest2-gke/deployer/common.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/klog"
 
+	"github.com/pkg/math"
 	"sigs.k8s.io/kubetest2/pkg/boskos"
 )
 
@@ -43,6 +44,8 @@ func (d *Deployer) Init() error {
 // Initialize should only be called by init(), behind a sync.Once
 func (d *Deployer) Initialize() error {
 	if d.kubetest2CommonOptions.ShouldUp() {
+		d.totalTryCount = math.Max(len(d.Regions), len(d.Zones))
+
 		if err := d.VerifyUpFlags(); err != nil {
 			return fmt.Errorf("init failed to verify flags for up: %w", err)
 		}

--- a/kubetest2-gke/deployer/deployer.go
+++ b/kubetest2-gke/deployer/deployer.go
@@ -111,9 +111,12 @@ type Deployer struct {
 	localLogsDir string
 	gcsLogsDir   string
 
-	// gke specific details
-	retryCount                     int
-	retryableErrorPatternsCompiled []*regexp.Regexp
+	// gke specific details for retrying
+	totalTryCount                        int
+	retryCount                           int
+	retryableErrorPatternsCompiled       []*regexp.Regexp
+	subnetworkRangesInternal             [][]string
+	privateClusterMasterIPRangesInternal [][]string
 
 	// boskos struct field will be non-nil when the deployer is
 	// using boskos to acquire a GCP project

--- a/kubetest2-gke/deployer/firewall.go
+++ b/kubetest2-gke/deployer/firewall.go
@@ -38,7 +38,7 @@ func (d *Deployer) EnsureFirewallRules() error {
 		return ensureFirewallRulesForSingleProject(project, d.Network, d.projectClustersLayout[project], d.instanceGroups)
 	}
 
-	return ensureFirewallRulesForMultiProjects(d.Projects, d.Network, d.SubnetworkRanges)
+	return ensureFirewallRulesForMultiProjects(d.Projects, d.Network, d.subnetworkRangesInternal[d.retryCount])
 }
 
 // Ensure firewall rules for e2e testing for all clusters in one single project.

--- a/kubetest2-gke/deployer/network.go
+++ b/kubetest2-gke/deployer/network.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"strings"
 
@@ -38,41 +39,115 @@ etag: %s
 `
 
 func (d *Deployer) VerifyNetworkFlags() error {
+
 	// Verify private cluster args.
-	if d.PrivateClusterAccessLevel != "" && d.PrivateClusterAccessLevel != string(no) &&
-		d.PrivateClusterAccessLevel != string(limited) && d.PrivateClusterAccessLevel != string(unrestricted) {
-		return fmt.Errorf("--private-cluster-access-level must be one of %v", []string{"", string(no), string(limited), string(unrestricted)})
-	}
-	if d.PrivateClusterAccessLevel != "" && len(d.Clusters) != len(d.PrivateClusterMasterIPRanges) {
-		return fmt.Errorf("--private-cluster-master-ip-range must have the same length as the number of clusters when requesting private cluster(s)")
+	if d.PrivateClusterAccessLevel != "" {
+		if d.PrivateClusterAccessLevel != string(no) &&
+			d.PrivateClusterAccessLevel != string(limited) && d.PrivateClusterAccessLevel != string(unrestricted) {
+			return fmt.Errorf("--private-cluster-access-level must be one of %v", []string{"", string(no), string(limited), string(unrestricted)})
+		}
+		if len(d.PrivateClusterMasterIPRanges) != len(d.Clusters)*d.totalTryCount {
+			return fmt.Errorf("the number of master ip ranges provided via --private-cluster-master-ip-range "+
+				"should be the same as the number of clusters times the total try count : %d!=%d", len(d.PrivateClusterMasterIPRanges), len(d.Clusters)*d.totalTryCount)
+		}
+		if err := assertNoOverlaps(d.PrivateClusterMasterIPRanges); err != nil {
+			return fmt.Errorf("error in private cluster master ip ranges: %v", err)
+		}
 	}
 
 	numProjects := len(d.Projects)
 	if numProjects == 0 {
 		numProjects = d.BoskosProjectsRequested
 	}
-	// For single project, no other verification is needed.
-	if numProjects == 1 {
-		return nil
-	}
 
-	if d.Network == "default" {
-		return errors.New("the default network cannot be used for multi-project profile")
-	}
+	// Verify for multi-project profile.
+	if numProjects > 1 {
+		if d.Network == "default" {
+			return errors.New("the default network cannot be used for multi-project profile")
+		}
 
-	if len(d.SubnetworkRanges) != numProjects-1 {
-		return fmt.Errorf("the number of subnetwork ranges provided "+
-			"should be the same as the number of service projects: %d!=%d", len(d.SubnetworkRanges), numProjects-1)
-	}
+		if len(d.SubnetworkRanges) != (numProjects-1)*d.totalTryCount {
+			return fmt.Errorf("the number of subnetwork ranges provided "+
+				"should be the same as the number of service projects times the total try count : %d!=%d", len(d.SubnetworkRanges), (numProjects-1)*d.totalTryCount)
+		}
 
-	for _, sr := range d.SubnetworkRanges {
-		parts := strings.Split(sr, " ")
-		if len(parts) != 3 {
-			return fmt.Errorf("the provided subnetwork range %s is not in the right format, should be like "+
-				"10.0.4.0/22 10.0.32.0/20 10.4.0.0/14", sr)
+		if err := d.validateSubnetRanges(); err != nil {
+			return err
 		}
 	}
 
+	if err := d.internalizeNetworkFlags(numProjects); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *Deployer) validateSubnetRanges() error {
+	// The subnets are passed in a list, each containing groups of 3 CIDR ranges.
+	// We need to verify there are no overlaps within the entire group.
+	var allSubnetRanges []string
+	for _, subnet := range d.SubnetworkRanges {
+		ranges := strings.Split(subnet, " ")
+		if len(ranges) != 3 {
+			return fmt.Errorf("the provided subnetwork range %s is not in the right format, should be like "+
+				"10.0.4.0/22 10.0.32.0/20 10.4.0.0/14", subnet)
+		}
+
+		allSubnetRanges = append(allSubnetRanges, ranges...)
+	}
+
+	if err := assertNoOverlaps(allSubnetRanges); err != nil {
+		return fmt.Errorf("error in subnetwork ranges: %v", err)
+	}
+
+	return nil
+}
+
+func assertNoOverlaps(ranges []string) error {
+	var allRanges []*net.IPNet
+	for _, rangeString := range ranges {
+		_, thisRange, err := net.ParseCIDR(rangeString)
+		if err != nil {
+			return fmt.Errorf("error parsing %q into a CIDR: %w", rangeString, err)
+		}
+		for _, previousRange := range allRanges {
+			if areOverlapping(thisRange, previousRange) {
+				return fmt.Errorf("overlap found within the provided ranges: (%v, %v)", thisRange, previousRange)
+			}
+		}
+		allRanges = append(allRanges, thisRange)
+	}
+	return nil
+}
+
+func areOverlapping(r1, r2 *net.IPNet) bool {
+	return r1.Contains(r2.IP) || r2.Contains(r1.IP)
+}
+
+func (d *Deployer) internalizeNetworkFlags(numProjects int) error {
+	d.subnetworkRangesInternal = make([][]string, d.totalTryCount)
+	for tc := 0; tc < d.totalTryCount; tc++ {
+		d.subnetworkRangesInternal[tc] = make([]string, numProjects-1)
+		for p := 0; p < numProjects-1; p++ {
+			index := tc*(numProjects-1) + p
+			d.subnetworkRangesInternal[tc][p] = d.SubnetworkRanges[index]
+		}
+	}
+
+	// Since len(d.PrivateClusterMasterIPRanges) is 0 when private cluster is not requested.
+	if d.PrivateClusterAccessLevel == "" {
+		return nil
+	}
+
+	d.privateClusterMasterIPRangesInternal = make([][]string, d.totalTryCount)
+	for tc := 0; tc < d.totalTryCount; tc++ {
+		d.privateClusterMasterIPRangesInternal[tc] = make([]string, len(d.Clusters))
+		for c := 0; c < len(d.Clusters); c++ {
+			index := tc*len(d.Clusters) + c
+			d.privateClusterMasterIPRangesInternal[tc][c] = d.PrivateClusterMasterIPRanges[index]
+		}
+	}
 	return nil
 }
 
@@ -108,7 +183,7 @@ func (d *Deployer) CreateSubnets() error {
 		return nil
 	}
 	hostProject := d.Projects[0]
-	for i, nr := range d.SubnetworkRanges {
+	for i, nr := range d.subnetworkRangesInternal[d.retryCount] {
 		serviceProject := d.Projects[i+1]
 		parts := strings.Split(nr, " ")
 		// The subnetwork name is in the format of `[main_network]-[service_project_id]`.

--- a/kubetest2-gke/deployer/network_test.go
+++ b/kubetest2-gke/deployer/network_test.go
@@ -131,3 +131,26 @@ func TestPrivateClusterArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestAssertNoOverlaps(t *testing.T) {
+	testCases := []struct {
+		ranges     []string
+		shouldPass bool
+	}{
+		{ranges: []string{"10.0.0.0/24", "11.0.0.0/24"}, shouldPass: true},
+		{ranges: []string{"10.0.0.0/24", "10.0.0.0/25"}, shouldPass: false},
+		{ranges: []string{"10.0.0.0/24", "11.0.0.0/24", "10.0.0.0/25"}, shouldPass: false},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		err := assertNoOverlaps(tc.ranges)
+		if (err == nil) != tc.shouldPass {
+			if tc.shouldPass {
+				t.Errorf("test case should have passed, but failed: %q (error: %w)", tc.ranges, err)
+			} else {
+				t.Errorf("test case should have failed, but passed: %q", tc.ranges)
+			}
+		}
+	}
+}

--- a/kubetest2-gke/deployer/up.go
+++ b/kubetest2-gke/deployer/up.go
@@ -130,7 +130,7 @@ func (d *Deployer) isRetryableError(err error) bool {
 }
 
 func (d *Deployer) CreateCluster(project string, cluster cluster, subNetworkArgs []string, locationArg string) error {
-	privateClusterArgs := privateClusterArgs(d.Projects, d.Network, d.PrivateClusterAccessLevel, d.PrivateClusterMasterIPRanges, cluster)
+	privateClusterArgs := privateClusterArgs(d.Projects, d.Network, d.PrivateClusterAccessLevel, d.privateClusterMasterIPRangesInternal[d.retryCount], cluster)
 	// Create the cluster
 	args := d.createCommand()
 	args = append(args,


### PR DESCRIPTION
kubetest2 gke deployer supports retries with different subnet ranges to avoid conflicts