### PR TITLE
Support Windows node pool in kubetest2-gke

### DIFF
--- a/kubetest2-gke/deployer/deployer.go
+++ b/kubetest2-gke/deployer/deployer.go
@@ -39,8 +39,9 @@ import (
 const Name = "gke"
 
 const (
-	e2eAllow     = "tcp:22,tcp:80,tcp:8080,tcp:30000-32767,udp:30000-32767"
-	defaultImage = "cos"
+	e2eAllow            = "tcp:22,tcp:80,tcp:8080,tcp:30000-32767,udp:30000-32767"
+	defaultImage        = "cos"
+	defaultWindowsImage = WindowsImageTypeLTSC
 )
 
 const (
@@ -65,9 +66,15 @@ var (
 	// m[3]: unique hash (used as nonce for firewall rules)
 	poolRe = regexp.MustCompile(`zones/([^/]+)/instanceGroupManagers/(gk[e|3]-.*-([0-9a-f]{8})-grp)$`)
 
-	urlRe           = regexp.MustCompile(`https://.*/`)
+	urlRe = regexp.MustCompile(`https://.*/`)
+
 	defaultNodePool = gkeNodePool{
 		Nodes:       3,
+		MachineType: "n1-standard-2",
+	}
+
+	defaultWindowsNodePool = gkeNodePool{
+		Nodes:       1,
 		MachineType: "n1-standard-2",
 	}
 )
@@ -154,10 +161,13 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 			Environment: "prod",
 		},
 		UpOptions: &options.UpOptions{
-			NumClusters: 1,
-			NumNodes:    defaultNodePool.Nodes,
-			MachineType: defaultNodePool.MachineType,
-			ImageType:   defaultImage,
+			NumClusters:        1,
+			NumNodes:           defaultNodePool.Nodes,
+			MachineType:        defaultNodePool.MachineType,
+			ImageType:          defaultImage,
+			WindowsNumNodes:    defaultWindowsNodePool.Nodes,
+			WindowsMachineType: defaultWindowsNodePool.MachineType,
+			WindowsImageType:   defaultWindowsImage,
 			// Leave Version as empty to use the default cluster version.
 			Version:          "",
 			GCPSSHKeyIgnored: true,

--- a/kubetest2-gke/deployer/options/up.go
+++ b/kubetest2-gke/deployer/options/up.go
@@ -32,6 +32,10 @@ type UpOptions struct {
 	Version                 string `desc:"Use a specific GKE version e.g. 1.16.13.gke-400, 'latest' or ''. If --build is specified it will default to building kubernetes from source."`
 	WorkloadIdentityEnabled bool   `flag:"~enable-workload-identity" desc:"Whether enable workload identity for the cluster or not. See the details in https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity."`
 	GCPSSHKeyIgnored        bool   `flag:"~ignore-gcp-ssh-key" desc:"Whether the GCP SSH key should be ignored or not for bringing up the cluster."`
+	WindowsEnabled          bool   `flag:"~enable-windows" desc:"Whether enable Windows node pool in the cluster or not."`
+	WindowsNumNodes         int    `flag:"~windows-num-nodes" desc:"For use with gcloud commands to specify the number of nodes for Windows node pools in the cluster."`
+	WindowsMachineType      string `flag:"~windows-machine-type" desc:"For use with gcloud commands to specify the machine type for Windows node in the cluster."`
+	WindowsImageType        string `flag:"~windows-image-type" desc:"The Windows image type to use for the cluster."`
 
 	BoskosLocation                 string `flag:"~boskos-location" desc:"If set, manually specifies the location of the Boskos server."`
 	BoskosResourceType             string `flag:"~boskos-resource-type" desc:"If set, manually specifies the resource type of GCP projects to acquire from Boskos."`


### PR DESCRIPTION
When --enable-windows is specified, it will add 2 Windows node pools
into the cluster, one using LTSC image, the other using SAC image.

New options include:
--enable-windows: Whether enable Windows node pool in the cluster or
not.
--windows-num-nodes: For use with gcloud commands to specify the number
of nodes for Windows node pools in the cluster.
--windows-machine-type: For use with gcloud commands to specify the
machine type for Windows node in the cluster.