### PR TITLE
[kubetest2-gke deployer] Automatically resolves the release channel if it's not specified

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
 	golang.org/x/sys v0.0.0-20201221093633-bc327ba9c2f0 // indirect
+	google.golang.org/api v0.36.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/klog v1.0.0
 	k8s.io/release v0.7.1-0.20210204090829-09fb5e3883b8

--- a/kubetest2-gke/deployer/commandutils.go
+++ b/kubetest2-gke/deployer/commandutils.go
@@ -26,7 +26,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"gopkg.in/yaml.v2"
 	"k8s.io/klog"
 
 	"sigs.k8s.io/kubetest2/pkg/exec"
@@ -120,39 +119,6 @@ func getClusterCredentials(project, loc, cluster string) error {
 	}
 
 	return nil
-}
-
-// Resolve the current latest version in the given release channel.
-func resolveLatestVersionInChannel(loc, channelName string) (string, error) {
-	// Get the server config for the current location.
-	out, err := exec.Output(exec.RawCommand(
-		fmt.Sprintf("gcloud container get-server-config --format=\"yaml(channels:format='yaml(channel,validVersions)')\" %s", loc)))
-	if err != nil {
-		return "", fmt.Errorf("failed to get the server config: %w", err)
-	}
-
-	type Channel struct {
-		Name          string   `yaml:"channel"`
-		ValidVersions []string `yaml:"validVersions"`
-	}
-	type Channels struct {
-		Channels []Channel `yaml:"channels"`
-	}
-	var cs Channels
-	if err = yaml.Unmarshal(out, &cs); err != nil {
-		return "", fmt.Errorf("failed to unmarshal the server config: %w", err)
-	}
-
-	for _, channel := range cs.Channels {
-		if strings.EqualFold(channel.Name, channelName) {
-			if len(channel.ValidVersions) == 0 {
-				return "", fmt.Errorf("no valid versions for channel %q", channelName)
-			}
-			return channel.ValidVersions[0], nil
-		}
-	}
-
-	return "", fmt.Errorf("channel %q does not exist in the server config", channelName)
 }
 
 func containerArgs(args ...string) []string {

--- a/kubetest2-gke/deployer/version.go
+++ b/kubetest2-gke/deployer/version.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"google.golang.org/api/container/v1"
+	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/kubetest2/pkg/exec"
+)
+
+var (
+	noneReleaseChannel    = "None"
+	rapidReleaseChannel   = "rapid"
+	regularReleaseChannel = "regular"
+	stableReleaseChannel  = "stable"
+
+	validReleaseChannels = []string{noneReleaseChannel, rapidReleaseChannel, regularReleaseChannel, stableReleaseChannel}
+)
+
+func validateVersion(version string) error {
+	switch version {
+	case "latest", "":
+		return nil
+	default:
+		re, err := regexp.Compile(`(\d)\.(\d)+(\.(\d)*(.*))?`)
+		if err != nil {
+			return err
+		}
+		if !re.MatchString(version) {
+			return fmt.Errorf("unknown version %q", version)
+		}
+	}
+	return nil
+}
+
+func validateReleaseChannel(releaseChannel string) error {
+	if releaseChannel != "" {
+		for _, c := range validReleaseChannels {
+			if releaseChannel == c {
+				return nil
+			}
+		}
+		return fmt.Errorf("%q is not one of the valid release channels %v", releaseChannel, validReleaseChannels)
+	}
+	return nil
+}
+
+// Resolve the current latest version in the given release channel.
+func resolveLatestVersionInChannel(loc, channelName string) (string, error) {
+	// Get the server config for the current location.
+	cfg, err := getServerConfig(loc)
+	if err != nil {
+		return "", fmt.Errorf("error getting server config: %w", err)
+	}
+	for _, channel := range cfg.Channels {
+		if strings.EqualFold(channel.Channel, channelName) {
+			if len(channel.ValidVersions) == 0 {
+				return "", fmt.Errorf("no valid versions for channel %q", channelName)
+			}
+			return channel.ValidVersions[0], nil
+		}
+	}
+
+	return "", fmt.Errorf("channel %q does not exist in the server config", channelName)
+}
+
+// Resolve the valid release channel for the given cluster version.
+func resolveReleaseChannelForClusterVersion(clusterVersion, loc string) (string, error) {
+	if clusterVersion == "" || clusterVersion == "latest" {
+		// For latest or non cluster version, always use none release channel.
+		return noneReleaseChannel, nil
+	}
+
+	// Get the server config.
+	cfg, err := getServerConfig(loc)
+	if err != nil {
+		return "", err
+	}
+
+	// Look through the versions not associated with a channel.
+	for _, v := range cfg.ValidMasterVersions {
+		if isClusterVersionMatch(clusterVersion, v) {
+			// Use None release channel if there is a match in the valid master versions.
+			return noneReleaseChannel, nil
+		}
+	}
+
+	// Look through all the channels.
+	for _, channel := range cfg.Channels {
+		for _, v := range channel.ValidVersions {
+			if isClusterVersionMatch(clusterVersion, v) {
+				return toReleaseChannel(channel.Channel)
+			}
+		}
+	}
+
+	return "", fmt.Errorf("no matched release channel found for cluster version %q", clusterVersion)
+}
+
+func toReleaseChannel(channelName string) (string, error) {
+	switch channelName {
+	case "RAPID":
+		return rapidReleaseChannel, nil
+	case "REGULAR":
+		return regularReleaseChannel, nil
+	case "STABLE":
+		return stableReleaseChannel, nil
+	default:
+		return "", fmt.Errorf("selected unknown release channel: %s", channelName)
+	}
+}
+
+// isClusterVersionMatch compares a cluster version against a match version. The match version can
+// be used to match against various patch versions. For example, the match version 1.7 will match
+// against versions 1.7.3 and 1.7.10.
+func isClusterVersionMatch(match, version string) bool {
+	if match == version {
+		return true
+	}
+
+	matchParts := strings.Split(match, ".")
+	// The version is in the format of major.minor.patch-gke.number, here we
+	// only need to match the major.minor.patch version.
+	if strings.Contains(version, "-") {
+		version = strings.Split(version, "-")[0]
+	}
+	parts := strings.Split(version, ".")
+
+	if len(parts) < len(matchParts) {
+		return false
+	}
+
+	for i := 0; i < len(matchParts); i++ {
+		if matchParts[i] != parts[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func getServerConfig(loc string) (*container.ServerConfig, error) {
+	// List the available versions for each release channel.
+	out, err := exec.Output(exec.RawCommand((fmt.Sprintf("gcloud container get-server-config --format=yaml %s", loc))))
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse the YAML into a struct.
+	cfg := &container.ServerConfig{}
+	if err := yaml.Unmarshal(out, cfg); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}

--- a/kubetest2-gke/deployer/version_test.go
+++ b/kubetest2-gke/deployer/version_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import (
+	"testing"
+)
+
+func TestValidateVersion(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		version string
+		valid   bool
+	}{
+		{
+			desc:    "empty version string is valid",
+			version: "",
+			valid:   true,
+		},
+		{
+			desc:    "latest version string is valid",
+			version: "latest",
+			valid:   true,
+		},
+		{
+			desc:    "major.minor version string is valid",
+			version: "1.16",
+			valid:   true,
+		},
+		{
+			desc:    "major.minor.patch version string is valid",
+			version: "1.16.8",
+			valid:   true,
+		},
+		{
+			desc:    "full version string is valid",
+			version: "1.16.13-gke.400",
+			valid:   true,
+		},
+		{
+			desc:    "arbitrary version string is invalid",
+			version: "abc.123",
+			valid:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(st *testing.T) {
+			st.Parallel()
+			err := validateVersion(tc.version)
+			if tc.valid && err != nil {
+				t.Errorf("unexpected error %v for %s", err, tc.version)
+			} else if !tc.valid && err == nil {
+				t.Error("expected error for case but got nil", tc.version)
+			}
+		})
+	}
+}
+
+func TestValidateReleaseChannel(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		releaseChannel string
+		valid          bool
+	}{
+		{
+			desc:           "empty release channel is valid",
+			releaseChannel: "",
+			valid:          true,
+		},
+		{
+			desc:           "None release channel is valid",
+			releaseChannel: "None",
+			valid:          true,
+		},
+		{
+			desc:           "rapid release channel is valid",
+			releaseChannel: "rapid",
+			valid:          true,
+		},
+		{
+			desc:           "regular release channel is valid",
+			releaseChannel: "regular",
+			valid:          true,
+		},
+		{
+			desc:           "stable release channel is valid",
+			releaseChannel: "stable",
+			valid:          true,
+		},
+		{
+			desc:           "latest release channel is invalid",
+			releaseChannel: "latest",
+			valid:          false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(st *testing.T) {
+			st.Parallel()
+			err := validateReleaseChannel(tc.releaseChannel)
+			if tc.valid && err != nil {
+				t.Errorf("unexpected error %v for %s", err, tc.releaseChannel)
+			} else if !tc.valid && err == nil {
+				t.Error("expected error for case but got nil", tc.releaseChannel)
+			}
+		})
+	}
+}
+
+func TestIsClusterVersionMatch(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		version       string
+		target        string
+		expectMatched bool
+	}{
+		{
+			desc:          "the same cluster version is a match",
+			version:       "1.19.10-gke.1000",
+			target:        "1.19.10-gke.1000",
+			expectMatched: true,
+		},
+		{
+			desc:          "the same major.minor version is a match",
+			version:       "1.19",
+			target:        "1.19.10-gke.1000",
+			expectMatched: true,
+		},
+		{
+			desc:          "the same major.minor.patch version is a match",
+			version:       "1.19.10",
+			target:        "1.19.10-gke.1000",
+			expectMatched: true,
+		},
+		{
+			desc:          "different major.minor.patch version is not a match",
+			version:       "1.20.1",
+			target:        "1.19.10-gke.1000",
+			expectMatched: false,
+		},
+		{
+			desc:          "the same prefix but different numbers is not a match",
+			version:       "1.19.1",
+			target:        "1.19.10-gke.1000",
+			expectMatched: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(st *testing.T) {
+			st.Parallel()
+			matched := isClusterVersionMatch(tc.version, tc.target)
+			if tc.expectMatched && !matched {
+				t.Error("expected the versions are matched but not")
+			} else if !tc.expectMatched && matched {
+				t.Error("expected the versions are not matched but got matched")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Sometimes when the users create the GKE clusters, they just want to specify a valid cluster version but do not want to hard code the channel, but if the version is only valid in a specific channel (e.g. rapid), the cluster creation will fail.

This PR adds the support to automatically resolve the release channel if it's not specified, so that as long as the specified version is in any of the valid release channels, `kubetest2 gke --up` will work.

/cc @amwat 