### PR TITLE
set SOURCE_DATE_EPOCH from kubeRepo when building

### DIFF
--- a/pkg/build/bazel.go
+++ b/pkg/build/bazel.go
@@ -48,9 +48,9 @@ func (b *Bazel) Build() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get version: %v", err)
 	}
-	setReproducibilityEnv(b.RepoRoot)
 	cmd := exec.Command("bazel", "build", "//build/release-tars")
 	cmd = cmd.SetDir(b.RepoRoot)
+	setSourceDateEpoch(b.RepoRoot, cmd)
 	exec.InheritOutput(cmd)
 	return version, cmd.Run()
 }

--- a/pkg/build/bazel.go
+++ b/pkg/build/bazel.go
@@ -48,6 +48,7 @@ func (b *Bazel) Build() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get version: %v", err)
 	}
+	setReproducibilityEnv(b.RepoRoot)
 	cmd := exec.Command("bazel", "build", "//build/release-tars")
 	cmd = cmd.SetDir(b.RepoRoot)
 	exec.InheritOutput(cmd)

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -99,3 +99,17 @@ func StoreCommonBinaries(kuberoot string, outroot string) {
 		}
 	}
 }
+
+// setReproducibilityEnv set the commit timestamp of kubeRoot for SOURCE_DATE_EPOCH env for reproducibility
+func setReproducibilityEnv(kubeRoot string) {
+	if os.Getenv("SOURCE_DATE_EPOCH") != "" {
+		return
+	}
+	cmd := exec.Command("git", "log", "-1", "--pretty=%ct")
+	cmd.SetDir(kubeRoot)
+	if output, err := exec.CombinedOutputLines(cmd); err != nil {
+		klog.Warningf("failed to compute SOURCE_DATE_EPOCH from git: %v", err)
+	} else {
+		os.Setenv("SOURCE_DATE_EPOCH", output[0])
+	}
+}

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -100,7 +100,9 @@ func StoreCommonBinaries(kuberoot string, outroot string) {
 	}
 }
 
-// setReproducibilityEnv set the commit timestamp of kubeRoot for SOURCE_DATE_EPOCH env for reproducibility
+// setReproducibilityEnv sets the SOURCE_DATE_EPOCH env to the commit timestamp of the latest commit in the
+// kubernetes repository, specified under kubeRoot, for reproducible builds
+// https://github.com/kubernetes/kubernetes/blob/7eae33cb0e1ead51c80ad517bc670113d77fa28d/build/README.md#reproducibility
 func setReproducibilityEnv(kubeRoot string) {
 	if os.Getenv("SOURCE_DATE_EPOCH") != "" {
 		return

--- a/pkg/build/make.go
+++ b/pkg/build/make.go
@@ -38,9 +38,9 @@ func (m *MakeBuilder) Build() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get version: %v", err)
 	}
-	setReproducibilityEnv(m.RepoRoot)
 	cmd := exec.Command("make", target)
 	cmd.SetDir(m.RepoRoot)
+	setSourceDateEpoch(m.RepoRoot, cmd)
 	exec.InheritOutput(cmd)
 	if err = cmd.Run(); err != nil {
 		return "", err

--- a/pkg/build/make.go
+++ b/pkg/build/make.go
@@ -38,6 +38,7 @@ func (m *MakeBuilder) Build() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get version: %v", err)
 	}
+	setReproducibilityEnv(m.RepoRoot)
 	cmd := exec.Command("make", target)
 	cmd.SetDir(m.RepoRoot)
 	exec.InheritOutput(cmd)


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/kubetest2/issues/101. 

Set the commit timestamp of kubeRoot for SOURCE_DATE_EPOCH env for reproducibility befor bazel & make build