### PR TITLE
Fix to kubetest2 gke deployer supports retries with different subnet ranges to avoid conflicts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
 	golang.org/x/sys v0.0.0-20201221093633-bc327ba9c2f0 // indirect
 	google.golang.org/api v0.36.0
-	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/klog v1.0.0
 	k8s.io/release v0.7.1-0.20210204090829-09fb5e3883b8
 	sigs.k8s.io/boskos v0.0.0-20200710214748-f5935686c7fc

--- a/kubetest2-gke/deployer/common.go
+++ b/kubetest2-gke/deployer/common.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/math"
 	"k8s.io/klog"
 
 	"sigs.k8s.io/kubetest2/pkg/boskos"
@@ -44,6 +45,8 @@ func (d *Deployer) Init() error {
 // Initialize should only be called by init(), behind a sync.Once
 func (d *Deployer) Initialize() error {
 	if d.kubetest2CommonOptions.ShouldUp() {
+		d.totalTryCount = math.Max(len(d.Regions), len(d.Zones))
+
 		if err := d.VerifyUpFlags(); err != nil {
 			return fmt.Errorf("init failed to verify flags for up: %w", err)
 		}

--- a/kubetest2-gke/deployer/deployer.go
+++ b/kubetest2-gke/deployer/deployer.go
@@ -111,9 +111,12 @@ type Deployer struct {
 	localLogsDir string
 	gcsLogsDir   string
 
-	// gke specific details
-	retryCount                     int
-	retryableErrorPatternsCompiled []*regexp.Regexp
+	// gke specific details for retrying
+	totalTryCount                        int
+	retryCount                           int
+	retryableErrorPatternsCompiled       []*regexp.Regexp
+	subnetworkRangesInternal             [][]string
+	privateClusterMasterIPRangesInternal [][]string
 
 	// boskos struct field will be non-nil when the deployer is
 	// using boskos to acquire a GCP project

--- a/kubetest2-gke/deployer/firewall.go
+++ b/kubetest2-gke/deployer/firewall.go
@@ -38,7 +38,7 @@ func (d *Deployer) EnsureFirewallRules() error {
 		return ensureFirewallRulesForSingleProject(project, d.Network, d.projectClustersLayout[project], d.instanceGroups)
 	}
 
-	return ensureFirewallRulesForMultiProjects(d.Projects, d.Network, d.SubnetworkRanges)
+	return ensureFirewallRulesForMultiProjects(d.Projects, d.Network, d.subnetworkRangesInternal[d.retryCount])
 }
 
 // Ensure firewall rules for e2e testing for all clusters in one single project.

--- a/kubetest2-gke/deployer/network.go
+++ b/kubetest2-gke/deployer/network.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"strings"
 
@@ -38,41 +39,115 @@ etag: %s
 `
 
 func (d *Deployer) VerifyNetworkFlags() error {
+
 	// Verify private cluster args.
-	if d.PrivateClusterAccessLevel != "" && d.PrivateClusterAccessLevel != string(no) &&
-		d.PrivateClusterAccessLevel != string(limited) && d.PrivateClusterAccessLevel != string(unrestricted) {
-		return fmt.Errorf("--private-cluster-access-level must be one of %v", []string{"", string(no), string(limited), string(unrestricted)})
-	}
-	if d.PrivateClusterAccessLevel != "" && len(d.Clusters) != len(d.PrivateClusterMasterIPRanges) {
-		return fmt.Errorf("--private-cluster-master-ip-range must have the same length as the number of clusters when requesting private cluster(s)")
+	if d.PrivateClusterAccessLevel != "" {
+		if d.PrivateClusterAccessLevel != string(no) &&
+			d.PrivateClusterAccessLevel != string(limited) && d.PrivateClusterAccessLevel != string(unrestricted) {
+			return fmt.Errorf("--private-cluster-access-level must be one of %v", []string{"", string(no), string(limited), string(unrestricted)})
+		}
+		if len(d.PrivateClusterMasterIPRanges) != len(d.Clusters)*d.totalTryCount {
+			return fmt.Errorf("the number of master ip ranges provided via --private-cluster-master-ip-range "+
+				"should be the same as the number of clusters times the total try count : %d!=%d", len(d.PrivateClusterMasterIPRanges), len(d.Clusters)*d.totalTryCount)
+		}
+		if err := assertNoOverlaps(d.PrivateClusterMasterIPRanges); err != nil {
+			return fmt.Errorf("error in private cluster master ip ranges: %v", err)
+		}
 	}
 
 	numProjects := len(d.Projects)
 	if numProjects == 0 {
 		numProjects = d.BoskosProjectsRequested
 	}
-	// For single project, no other verification is needed.
-	if numProjects == 1 {
-		return nil
-	}
 
-	if d.Network == "default" {
-		return errors.New("the default network cannot be used for multi-project profile")
-	}
+	// Verify for multi-project profile.
+	if numProjects > 1 {
+		if d.Network == "default" {
+			return errors.New("the default network cannot be used for multi-project profile")
+		}
 
-	if len(d.SubnetworkRanges) != numProjects-1 {
-		return fmt.Errorf("the number of subnetwork ranges provided "+
-			"should be the same as the number of service projects: %d!=%d", len(d.SubnetworkRanges), numProjects-1)
-	}
+		if len(d.SubnetworkRanges) != (numProjects-1)*d.totalTryCount {
+			return fmt.Errorf("the number of subnetwork ranges provided "+
+				"should be the same as the number of service projects times the total try count : %d!=%d", len(d.SubnetworkRanges), (numProjects-1)*d.totalTryCount)
+		}
 
-	for _, sr := range d.SubnetworkRanges {
-		parts := strings.Split(sr, " ")
-		if len(parts) != 3 {
-			return fmt.Errorf("the provided subnetwork range %s is not in the right format, should be like "+
-				"10.0.4.0/22 10.0.32.0/20 10.4.0.0/14", sr)
+		if err := validateSubnetRanges(d.SubnetworkRanges); err != nil {
+			return err
 		}
 	}
 
+	if err := d.internalizeNetworkFlags(numProjects); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateSubnetRanges(subnetworkRanges []string) error {
+	// The subnets are passed in a list, each containing groups of 3 CIDR ranges.
+	// We need to verify there are no overlaps within the entire group.
+	var allSubnetRanges []string
+	for _, subnet := range subnetworkRanges {
+		ranges := strings.Split(subnet, " ")
+		if len(ranges) != 3 {
+			return fmt.Errorf("the provided subnetwork range %s is not in the right format, should be like "+
+				"10.0.4.0/22 10.0.32.0/20 10.4.0.0/14", subnet)
+		}
+
+		allSubnetRanges = append(allSubnetRanges, ranges...)
+	}
+
+	if err := assertNoOverlaps(allSubnetRanges); err != nil {
+		return fmt.Errorf("error in subnetwork ranges: %v", err)
+	}
+
+	return nil
+}
+
+func assertNoOverlaps(ranges []string) error {
+	var allRanges []*net.IPNet
+	for _, rangeString := range ranges {
+		_, thisRange, err := net.ParseCIDR(rangeString)
+		if err != nil {
+			return fmt.Errorf("error parsing %q into a CIDR: %w", rangeString, err)
+		}
+		for _, previousRange := range allRanges {
+			if areOverlapping(thisRange, previousRange) {
+				return fmt.Errorf("overlap found within the provided ranges: (%v, %v)", thisRange, previousRange)
+			}
+		}
+		allRanges = append(allRanges, thisRange)
+	}
+	return nil
+}
+
+func areOverlapping(r1, r2 *net.IPNet) bool {
+	return r1.Contains(r2.IP) || r2.Contains(r1.IP)
+}
+
+func (d *Deployer) internalizeNetworkFlags(numProjects int) error {
+	d.subnetworkRangesInternal = make([][]string, d.totalTryCount)
+	for tc := 0; tc < d.totalTryCount; tc++ {
+		d.subnetworkRangesInternal[tc] = make([]string, numProjects-1)
+		for p := 0; p < numProjects-1; p++ {
+			index := tc*(numProjects-1) + p
+			d.subnetworkRangesInternal[tc][p] = d.SubnetworkRanges[index]
+		}
+	}
+
+	// Since len(d.PrivateClusterMasterIPRanges) is 0 when private cluster is not requested.
+	if d.PrivateClusterAccessLevel == "" {
+		return nil
+	}
+
+	d.privateClusterMasterIPRangesInternal = make([][]string, d.totalTryCount)
+	for tc := 0; tc < d.totalTryCount; tc++ {
+		d.privateClusterMasterIPRangesInternal[tc] = make([]string, len(d.Clusters))
+		for c := 0; c < len(d.Clusters); c++ {
+			index := tc*len(d.Clusters) + c
+			d.privateClusterMasterIPRangesInternal[tc][c] = d.PrivateClusterMasterIPRanges[index]
+		}
+	}
 	return nil
 }
 
@@ -108,7 +183,7 @@ func (d *Deployer) CreateSubnets() error {
 		return nil
 	}
 	hostProject := d.Projects[0]
-	for i, nr := range d.SubnetworkRanges {
+	for i, nr := range d.subnetworkRangesInternal[d.retryCount] {
 		serviceProject := d.Projects[i+1]
 		parts := strings.Split(nr, " ")
 		// The subnetwork name is in the format of `[main_network]-[service_project_id]`.

--- a/kubetest2-gke/deployer/network.go
+++ b/kubetest2-gke/deployer/network.go
@@ -447,11 +447,7 @@ func removeHostServiceAgentUserRole(projects []string) error {
 
 // This function returns the args required for creating a private cluster.
 // Reference: https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#top_of_page
-func privateClusterArgs(projects []string, network, accessLevel string, masterIPRanges []string, clusterInfo cluster) []string {
-	if accessLevel == "" {
-		return []string{}
-	}
-
+func getPrivateClusterArgs(projects []string, network, accessLevel string, masterIPRanges []string, clusterInfo cluster) []string {
 	common := []string{
 		"--enable-ip-alias",
 		"--enable-private-nodes",

--- a/kubetest2-gke/deployer/network_test.go
+++ b/kubetest2-gke/deployer/network_test.go
@@ -131,3 +131,35 @@ func TestPrivateClusterArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestAssertNoOverlaps(t *testing.T) {
+	testCases := []struct {
+		ranges     []string
+		shouldPass bool
+	}{
+		{
+			ranges:     []string{"10.0.0.0/24", "11.0.0.0/24"},
+			shouldPass: true,
+		},
+		{
+			ranges:     []string{"10.0.0.0/24", "10.0.0.0/25"},
+			shouldPass: false,
+		},
+		{
+			ranges:     []string{"10.0.0.0/24", "11.0.0.0/24", "10.0.0.0/25"},
+			shouldPass: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		err := assertNoOverlaps(tc.ranges)
+		if (err == nil) != tc.shouldPass {
+			if tc.shouldPass {
+				t.Errorf("test case should have passed, but failed: %q (error: %w)", tc.ranges, err)
+			} else {
+				t.Errorf("test case should have failed, but passed: %q", tc.ranges)
+			}
+		}
+	}
+}

--- a/kubetest2-gke/deployer/network_test.go
+++ b/kubetest2-gke/deployer/network_test.go
@@ -33,24 +33,6 @@ func TestPrivateClusterArgs(t *testing.T) {
 		expected       []string
 	}{
 		{
-			desc:           "no private cluster args are needed for non-private clusters",
-			projects:       []string{"project1"},
-			network:        "whatever-network",
-			accessLevel:    "",
-			masterIPRanges: []string{"whatever-master-IP-range"},
-			clusterInfo:    cluster{index: 0, name: "whatever-cluster-name"},
-			expected:       []string{},
-		},
-		{
-			desc:           "--private-cluster-master-ip-range can be empty for non-private clusters",
-			projects:       []string{"project1"},
-			network:        "whatever-network",
-			accessLevel:    "",
-			masterIPRanges: []string{},
-			clusterInfo:    cluster{index: 0, name: "whatever-cluster-name"},
-			expected:       []string{},
-		},
-		{
 			desc:           "test private cluster args for private cluster with no limit",
 			projects:       []string{"project1"},
 			network:        "test-network1",
@@ -124,7 +106,7 @@ func TestPrivateClusterArgs(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(st *testing.T) {
 			st.Parallel()
-			actual := privateClusterArgs(tc.projects, tc.network, tc.accessLevel, tc.masterIPRanges, tc.clusterInfo)
+			actual := getPrivateClusterArgs(tc.projects, tc.network, tc.accessLevel, tc.masterIPRanges, tc.clusterInfo)
 			if diff := cmp.Diff(actual, tc.expected); diff != "" {
 				st.Error("Got private cluster args (-want, +got) =", diff)
 			}

--- a/kubetest2-gke/deployer/up.go
+++ b/kubetest2-gke/deployer/up.go
@@ -129,7 +129,10 @@ func (d *Deployer) isRetryableError(err error) bool {
 }
 
 func (d *Deployer) CreateCluster(project string, cluster cluster, subNetworkArgs []string, locationArg string) error {
-	privateClusterArgs := privateClusterArgs(d.Projects, d.Network, d.PrivateClusterAccessLevel, d.PrivateClusterMasterIPRanges, cluster)
+	privateClusterArgs := []string{}
+	if d.PrivateClusterAccessLevel != "" {
+		privateClusterArgs = getPrivateClusterArgs(d.Projects, d.Network, d.PrivateClusterAccessLevel, d.PrivateClusterMasterIPRanges, cluster)
+	}
 	// Create the cluster
 	args := d.createCommand()
 	args = append(args,

--- a/kubetest2-gke/deployer/version.go
+++ b/kubetest2-gke/deployer/version.go
@@ -17,12 +17,12 @@ limitations under the License.
 package deployer
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
 
 	"google.golang.org/api/container/v1"
-	"gopkg.in/yaml.v2"
 	"sigs.k8s.io/kubetest2/pkg/exec"
 )
 
@@ -158,14 +158,14 @@ func isClusterVersionMatch(match, version string) bool {
 
 func getServerConfig(loc string) (*container.ServerConfig, error) {
 	// List the available versions for each release channel.
-	out, err := exec.Output(exec.RawCommand((fmt.Sprintf("gcloud container get-server-config --format=yaml %s", loc))))
+	out, err := exec.Output(exec.RawCommand((fmt.Sprintf("gcloud container get-server-config --format=json %s", loc))))
 	if err != nil {
 		return nil, err
 	}
 
-	// Parse the YAML into a struct.
+	// Parse the JSON into a struct.
 	cfg := &container.ServerConfig{}
-	if err := yaml.Unmarshal(out, cfg); err != nil {
+	if err := json.Unmarshal(out, cfg); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
1. Fix to the issue in https://github.com/kubernetes-sigs/kubetest2/commit/66afb490ec30c4f12f621a63f1c6cad42247a35f#r52588671
2. Also fix one issue in parsing the server config - yaml unmarshal has some issues with parsing the nested structs, switching to json instead.

I have tested it in our existing CI flows and everything works fine. 

