### PR TITLE
Fix two bugs for kubetest2 gke retry

### DIFF
--- a/kubetest2-gke/deployer/commandutils.go
+++ b/kubetest2-gke/deployer/commandutils.go
@@ -140,7 +140,7 @@ func runWithOutputAndReturn(cmd exec.Cmd) (string, error) {
 
 	exec.SetOutput(cmd, io.MultiWriter(os.Stdout, &buf), io.MultiWriter(os.Stderr, &buf))
 	if err := cmd.Run(); err != nil {
-		return "", err
+		return buf.String(), err
 	}
 	return buf.String(), nil
 }

--- a/kubetest2-gke/deployer/up.go
+++ b/kubetest2-gke/deployer/up.go
@@ -131,7 +131,7 @@ func (d *Deployer) isRetryableError(err error) bool {
 func (d *Deployer) CreateCluster(project string, cluster cluster, subNetworkArgs []string, locationArg string) error {
 	privateClusterArgs := []string{}
 	if d.PrivateClusterAccessLevel != "" {
-		privateClusterArgs = getPrivateClusterArgs(d.Projects, d.Network, d.PrivateClusterAccessLevel, d.PrivateClusterMasterIPRanges, cluster)
+		privateClusterArgs = getPrivateClusterArgs(d.Projects, d.Network, d.PrivateClusterAccessLevel, d.privateClusterMasterIPRangesInternal[d.retryCount], cluster)
 	}
 	// Create the cluster
 	args := d.createCommand()


### PR DESCRIPTION
1. Return the `gcloud` output if the cluster creation command fails. This will be used for matching the retryable error pattern to determine whether to retry or not.
2. Fix the private cluster master IP ranges when retrying.

I have manually tested the change and everything works.

/cc @amwat @BenTheElder 