### PR TITLE
Add windows/amd64 in target platform

### DIFF
--- a/kubetest2-gke/deployer/build/gke_make.go
+++ b/kubetest2-gke/deployer/build/gke_make.go
@@ -90,7 +90,7 @@ func (gmb *GKEMake) Build() (string, error) {
 
 	// Skip validation for faster builds
 	// TODO: add support for a separate validate mode
-	if err := gmb.runWithActions(os.Stdout, os.Stderr, []gkeBuildAction{compile, pack}, arg("VERSION", version)); err != nil {
+	if err := gmb.runWithActions(os.Stdout, os.Stderr, []gkeBuildAction{compile, pack}, arg("VERSION", version), arg("TARGET_PLATFORMS", "linux/amd64,windows/amd64")); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
The build only builds `linux/amd64` now.