### PR TITLE
Do not set --workload-pool when creating GKE autopilot clusters

### DIFF
--- a/kubetest2-gke/deployer/firewall.go
+++ b/kubetest2-gke/deployer/firewall.go
@@ -57,7 +57,7 @@ func ensureFirewallRulesForSingleProject(project, network string, clusters []clu
 
 		tagOut, err := exec.Output(exec.Command("gcloud", "compute", "instances", "list",
 			"--project="+project,
-			"--filter=metadata.created-by:*"+instanceGroups[project][clusterName][0].path,
+			"--filter=metadata.created-by:"+instanceGroups[project][clusterName][0].path,
 			"--limit=1",
 			"--format=get(tags.items)"))
 		if err != nil {

--- a/kubetest2-gke/deployer/up.go
+++ b/kubetest2-gke/deployer/up.go
@@ -163,11 +163,11 @@ func (d *Deployer) CreateCluster(project string, cluster cluster, subNetworkArgs
 		args = append(args, "--machine-type="+d.MachineType)
 		args = append(args, "--num-nodes="+strconv.Itoa(d.NumNodes))
 		args = append(args, "--image-type="+d.ImageType)
+		if d.WorkloadIdentityEnabled {
+			args = append(args, fmt.Sprintf("--workload-pool=%s.svc.id.goog", project))
+		}
 	}
 
-	if d.WorkloadIdentityEnabled {
-		args = append(args, fmt.Sprintf("--workload-pool=%s.svc.id.goog", project))
-	}
 	if d.ReleaseChannel != "" {
 		args = append(args, "--release-channel="+d.ReleaseChannel)
 		if d.Version == "latest" {


### PR DESCRIPTION
`--workload-pool` flag is not supported by the `gcloud container clusters create-auto` command as in https://cloud.google.com/sdk/gcloud/reference/container/clusters/create-auto

Also by the way fix one `gcloud compute instance list` command that is to be deprecated:

Before:
```
chizhg@chizhg-macbookpro:~$ gcloud compute instances list --project=test-asm-chizhg --filter=metadata.created-by:*zones/us-central1-b/instanceGroupManagers/gk3-prow-test1-default-pool-0b6b429f-grp --limit=1 --format='get(tags.items)'
WARNING: --filter : operator evaluation is changing for consistency across Google APIs.  metadata.created-by:*zones/us-central1-b/instanceGroupManagers/gk3-prow-test1-default-pool-0b6b429f-grp currently matches but will not match in the near future.  Run `gcloud topic filters` for details.
gke-prow-test1-c85f4ea1-node
```

After:
```
chizhg@chizhg-macbookpro:~$ gcloud compute instances list --project=test-asm-chizhg --filter=metadata.created-by:zones/us-central1-b/instanceGroupManagers/gk3-prow-test1-default-pool-0b6b429f-grp --limit=1 --format='get(tags.items)'
gke-prow-test1-c85f4ea1-node
```

