### PR TITLE
Implemented the update-latest flag for gke_make

### DIFF
--- a/kubetest2-gke/deployer/build/gke_make.go
+++ b/kubetest2-gke/deployer/build/gke_make.go
@@ -129,7 +129,7 @@ func (gmb *GKEMake) Stage(version string) error {
 			minor := m[1]
 			fName = fmt.Sprintf("latest-%s.txt", minor)
 		}
-		pushCmd := fmt.Sprintf("gsutil cp - %s/%s", gmb.StageLocation, fName)
+		pushCmd := fmt.Sprintf("gsutil -h 'Content-Type:text/plain' cp - %s/%s", gmb.StageLocation, fName)
 		cmd := exec.RawCommand(pushCmd)
 		cmd.SetStdin(strings.NewReader(version))
 		exec.SetOutput(cmd, os.Stdout, os.Stderr)

--- a/kubetest2-gke/deployer/build/gke_make.go
+++ b/kubetest2-gke/deployer/build/gke_make.go
@@ -44,7 +44,7 @@ const (
 )
 
 var (
-	gkeMinorVersionRegex = regexp.MustCompile("^v(\\d\\.\\d+).*$")
+	gkeMinorVersionRegex = regexp.MustCompile(`^v(\\d\\.\\d+).*$`)
 )
 
 type GKEMake struct {

--- a/kubetest2-gke/deployer/options/build.go
+++ b/kubetest2-gke/deployer/options/build.go
@@ -42,6 +42,7 @@ func (bo *BuildOptions) Validate() error {
 					BuildScript:   bo.BuildScript,
 					VersionSuffix: bo.CommonBuildOptions.VersionSuffix,
 					StageLocation: bo.CommonBuildOptions.StageLocation,
+					UpdateLatest:  bo.CommonBuildOptions.UpdateLatest,
 				}
 				bo.CommonBuildOptions.Builder = gkeMake
 				bo.CommonBuildOptions.Stager = gkeMake

--- a/pkg/build/krel.go
+++ b/pkg/build/krel.go
@@ -30,6 +30,7 @@ type Krel struct {
 	ImageLocation   string
 	RepoRoot        string
 	StageExtraFiles bool
+	UpdateLatest    bool
 }
 
 var _ Stager = &Krel{}
@@ -52,7 +53,7 @@ func (rpb *Krel) Stage(version string) error {
 			GCSRoot:         mat[3],
 			AllowDup:        true,
 			CI:              mat[2] == "ci",
-			NoUpdateLatest:  true,
+			NoUpdateLatest:  !rpb.UpdateLatest,
 			Registry:        rpb.ImageLocation,
 			Version:         version,
 			StageExtraFiles: rpb.StageExtraFiles,

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -65,6 +65,7 @@ func (o *Options) implementationFromStrategy() error {
 			StageLocation:   o.StageLocation,
 			ImageLocation:   o.ImageLocation,
 			StageExtraFiles: o.StageExtraGCPFiles,
+			UpdateLatest:    o.UpdateLatest,
 		}
 	default:
 		return fmt.Errorf("unknown build strategy: %v", o.Strategy)

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -37,6 +37,7 @@ type Options struct {
 	ImageLocation      string `flag:"~image-location" desc:"Image registry where built images are stored."`
 	StageExtraGCPFiles bool   `flag:"-"`
 	VersionSuffix      string `flag:"-"`
+	UpdateLatest       bool   `flag:"~update-latest" desc:"Whether should upload the build number to the GCS"`
 	Builder
 	Stager
 }


### PR DESCRIPTION
When the --update-latest flag is set to true, gke_make would upload the build number to gob-prow GCS after the build completes