### PR TITLE
Add version support for all binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ install:
 
 install-deployer-%: BINARY_PATH=./kubetest2-$*
 install-deployer-%: BINARY_NAME=kubetest2-$*
+install-deployer-%: BUILD_FLAGS=-trimpath -ldflags="-buildid= -X=sigs.k8s.io/kubetest2/kubetest2-$*/deployer.GitTag=$(COMMIT)"
 install-deployer-%:
 	go build -v $(BUILD_FLAGS) -o $(OUT_DIR)/$(BINARY_NAME) $(BINARY_PATH)
 	$(INSTALL) -d $(INSTALL_DIR)

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ install-deployer-%:
 
 install-tester-%: BINARY_PATH=./kubetest2-tester-$*
 install-tester-%: BINARY_NAME=kubetest2-tester-$*
+install-tester-%: BUILD_FLAGS=-trimpath -ldflags="-buildid= -X=sigs.k8s.io/kubetest2/pkg/testers/$*.GitTag=$(COMMIT)"
 install-tester-%:
 	go build $(BUILD_FLAGS) -v $(BUILD_OPTS) -o $(OUT_DIR)/$(BINARY_NAME) $(BINARY_PATH)
 	$(INSTALL) -d $(INSTALL_DIR)

--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,12 @@ SPACE:=$(subst ,, )
 SHELL:=env PATH=$(subst $(SPACE),\$(SPACE),$(PATH)) $(SHELL)
 # ==============================================================================
 # flags for reproducible go builds
-BUILD_FLAGS?=-trimpath -ldflags="-buildid= -X=sigs.k8s.io/kubetest2/pkg/app.GitTag=$(COMMIT)"
+BUILD_FLAGS?=-trimpath -ldflags="-buildid="
 
 build-all:
 	go build -v $(BUILD_FLAGS) ./...
 
+install: BUILD_FLAGS=-trimpath -ldflags="-buildid= -X=sigs.k8s.io/kubetest2/pkg/app/shim.GitTag=$(COMMIT)"
 install:
 	go build -v $(BUILD_FLAGS) -o $(OUT_DIR)/$(BINARY_NAME) $(BINARY_PATH)
 	$(INSTALL) -d $(INSTALL_DIR)

--- a/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2-gce/deployer/deployer.go
@@ -152,6 +152,10 @@ func (d *deployer) Provider() string {
 	return Name
 }
 
+func (d *deployer) Version() string {
+	return GitTag
+}
+
 func (d *deployer) Kubeconfig() (string, error) {
 	_, err := os.Stat(d.kubeconfigPath)
 	if os.IsNotExist(err) {

--- a/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2-gce/deployer/deployer.go
@@ -39,6 +39,8 @@ import (
 // Name is the name of the deployer
 const Name = "gce"
 
+var GitTag string
+
 type deployer struct {
 	// generic parts
 	commonOptions types.Options

--- a/kubetest2-gke/deployer/build.go
+++ b/kubetest2-gke/deployer/build.go
@@ -86,7 +86,7 @@ func (d *Deployer) Build() error {
 			return fmt.Errorf("error staging build: %v", err)
 		}
 	}
-	d.Version = version
+	d.ClusterVersion = version
 	build.StoreCommonBinaries(d.RepoRoot, d.kubetest2CommonOptions.RunDir())
 	return nil
 }

--- a/kubetest2-gke/deployer/common.go
+++ b/kubetest2-gke/deployer/common.go
@@ -44,6 +44,10 @@ func (d *Deployer) Init() error {
 
 // Initialize should only be called by init(), behind a sync.Once
 func (d *Deployer) Initialize() error {
+	if d.ClusterVersion == "" && d.LegacyClusterVersion != "" {
+		klog.Warningf("--version is deprecated please use --cluster-version")
+		d.ClusterVersion = d.LegacyClusterVersion
+	}
 	if d.kubetest2CommonOptions.ShouldUp() {
 		d.totalTryCount = math.Max(len(d.Regions), len(d.Zones))
 

--- a/kubetest2-gke/deployer/deployer.go
+++ b/kubetest2-gke/deployer/deployer.go
@@ -38,6 +38,8 @@ import (
 // Name is the name of the deployer
 const Name = "gke"
 
+var GitTag string
+
 const (
 	e2eAllow            = "tcp:22,tcp:80,tcp:8080,tcp:30000-32767,udp:30000-32767"
 	defaultImage        = "cos"

--- a/kubetest2-gke/deployer/deployer.go
+++ b/kubetest2-gke/deployer/deployer.go
@@ -146,6 +146,10 @@ func (d *Deployer) Provider() string {
 	return Name
 }
 
+func (d *Deployer) Version() string {
+	return GitTag
+}
+
 // New implements deployer.New for gke
 func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 	// create a deployer object and set fields that are not flag controlled
@@ -171,7 +175,7 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 			WindowsMachineType: defaultWindowsNodePool.MachineType,
 			WindowsImageType:   defaultWindowsImage,
 			// Leave Version as empty to use the default cluster version.
-			Version:          "",
+			ClusterVersion:   "",
 			GCPSSHKeyIgnored: true,
 
 			BoskosLocation:                 defaultBoskosLocation,

--- a/kubetest2-gke/deployer/deployer.go
+++ b/kubetest2-gke/deployer/deployer.go
@@ -174,7 +174,7 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 			WindowsNumNodes:    defaultWindowsNodePool.Nodes,
 			WindowsMachineType: defaultWindowsNodePool.MachineType,
 			WindowsImageType:   defaultWindowsImage,
-			// Leave Version as empty to use the default cluster version.
+			// Leave ClusterVersion as empty to use the default cluster version.
 			ClusterVersion:   "",
 			GCPSSHKeyIgnored: true,
 

--- a/kubetest2-gke/deployer/options/up.go
+++ b/kubetest2-gke/deployer/options/up.go
@@ -29,7 +29,8 @@ type UpOptions struct {
 	NumNodes                int    `flag:"~num-nodes" desc:"For use with gcloud commands to specify the number of nodes for the cluster."`
 	ImageType               string `flag:"~image-type" desc:"The image type to use for the cluster."`
 	ReleaseChannel          string `desc:"Use a GKE release channel, could be one of empty, rapid, regular and stable - https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels"`
-	Version                 string `desc:"Use a specific GKE version e.g. 1.16.13.gke-400, 'latest' or ''. If --build is specified it will default to building kubernetes from source."`
+	ClusterVersion          string `desc:"Use a specific GKE version e.g. 1.16.13.gke-400, 'latest' or ''. If --build is specified it will default to building kubernetes from source."`
+	LegacyClusterVersion    string `flag:"~version,deprecated" desc:"Use --cluster-version instead"`
 	WorkloadIdentityEnabled bool   `flag:"~enable-workload-identity" desc:"Whether enable workload identity for the cluster or not. See the details in https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity."`
 	GCPSSHKeyIgnored        bool   `flag:"~ignore-gcp-ssh-key" desc:"Whether the GCP SSH key should be ignored or not for bringing up the cluster."`
 	WindowsEnabled          bool   `flag:"~enable-windows" desc:"Whether enable Windows node pool in the cluster or not."`

--- a/kubetest2-gke/deployer/up.go
+++ b/kubetest2-gke/deployer/up.go
@@ -170,7 +170,7 @@ func (d *Deployer) CreateCluster(project string, cluster cluster, subNetworkArgs
 
 	if d.ReleaseChannel != "" {
 		args = append(args, "--release-channel="+d.ReleaseChannel)
-		if d.Version == "latest" {
+		if d.ClusterVersion == "latest" {
 			// If latest is specified, get the latest version from server config for this channel.
 			actualVersion, err := resolveLatestVersionInChannel(locationArg, d.ReleaseChannel)
 			if err != nil {
@@ -179,13 +179,13 @@ func (d *Deployer) CreateCluster(project string, cluster cluster, subNetworkArgs
 			klog.V(0).Infof("Using the latest version %q in %q channel", actualVersion, d.ReleaseChannel)
 			args = append(args, "--cluster-version="+actualVersion)
 		} else {
-			args = append(args, "--cluster-version="+d.Version)
+			args = append(args, "--cluster-version="+d.ClusterVersion)
 		}
 	} else {
-		args = append(args, "--cluster-version="+d.Version)
-		releaseChannel, err := resolveReleaseChannelForClusterVersion(d.Version, locationArg)
+		args = append(args, "--cluster-version="+d.ClusterVersion)
+		releaseChannel, err := resolveReleaseChannelForClusterVersion(d.ClusterVersion, locationArg)
 		if err != nil {
-			klog.Warningf("error resolving the release channel for %q: %v, will proceed with no channel", d.Version, err)
+			klog.Warningf("error resolving the release channel for %q: %v, will proceed with no channel", d.ClusterVersion, err)
 		} else {
 			args = append(args, "--release-channel="+releaseChannel)
 		}
@@ -352,7 +352,7 @@ func (d *Deployer) VerifyUpFlags() error {
 	if d.NumNodes <= 0 {
 		return fmt.Errorf("--num-nodes must be larger than 0")
 	}
-	if err := validateVersion(d.Version); err != nil {
+	if err := validateVersion(d.ClusterVersion); err != nil {
 		return err
 	}
 	if err := validateReleaseChannel(d.ReleaseChannel); err != nil {

--- a/kubetest2-kind/deployer/deployer.go
+++ b/kubetest2-kind/deployer/deployer.go
@@ -32,6 +32,8 @@ import (
 // Name is the name of the deployer
 const Name = "kind"
 
+var GitTag string
+
 // New implements deployer.New for kind
 func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 	// create a deployer object and set fields that are not flag controlled

--- a/kubetest2-kind/deployer/deployer.go
+++ b/kubetest2-kind/deployer/deployer.go
@@ -73,6 +73,10 @@ func (d *deployer) Kubeconfig() (string, error) {
 	return filepath.Join(home, ".kube", "config"), nil
 }
 
+func (d *deployer) Version() string {
+	return GitTag
+}
+
 // helper used to create & bind a flagset to the deployer
 func bindFlags(d *deployer) *pflag.FlagSet {
 	flags, err := gpflag.Parse(d)

--- a/kubetest2-noop/deployer/deployer.go
+++ b/kubetest2-noop/deployer/deployer.go
@@ -32,6 +32,8 @@ import (
 // Name is the name of the deployer
 const Name = "noop"
 
+var GitTag string
+
 // New implements deployer.New for kind
 func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 	// create a deployer object and set fields that are not flag controlled

--- a/kubetest2-noop/deployer/deployer.go
+++ b/kubetest2-noop/deployer/deployer.go
@@ -90,6 +90,10 @@ func (d *deployer) Kubeconfig() (string, error) {
 	return filepath.Join(home, ".kube", "config"), nil
 }
 
+func (d *deployer) Version() string {
+	return GitTag
+}
+
 // helper used to create & bind a flagset to the deployer
 func bindFlags(d *deployer) *pflag.FlagSet {
 	flags, err := gpflag.Parse(d)

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -63,7 +63,7 @@ func RealMain(opts types.Options, d types.Deployer, tester types.Tester) (result
 		return err
 	}
 
-	if err := writeVersionToMetadataJSON(opts); err != nil {
+	if err := writeVersionToMetadataJSON(opts, d); err != nil {
 		return err
 	}
 
@@ -164,7 +164,7 @@ func RealMain(opts types.Options, d types.Deployer, tester types.Tester) (result
 	return nil
 }
 
-func writeVersionToMetadataJSON(opts types.Options) error {
+func writeVersionToMetadataJSON(opts types.Options, d types.Deployer) error {
 	// setup the json metadata writer
 	metadataJSON, err := os.Create(
 		filepath.Join(opts.RunDir(), "metadata.json"),
@@ -179,6 +179,12 @@ func writeVersionToMetadataJSON(opts types.Options) error {
 	}
 	if err := meta.Add("kubetest-version", os.Getenv("KUBETEST2_VERSION")); err != nil {
 		return err
+	}
+
+	if dWithVersion, ok := d.(types.DeployerWithVersion); ok {
+		if err := meta.Add("deployer-version", dWithVersion.Version()); err != nil {
+			return err
+		}
 	}
 
 	if err := meta.Write(metadataJSON); err != nil {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -63,7 +63,11 @@ func RealMain(opts types.Options, d types.Deployer, tester types.Tester) (result
 		return err
 	}
 
-	// setup the metadata writer
+	if err := writeVersionToMetadataJSON(opts); err != nil {
+		return err
+	}
+
+	// setup junit writer
 	junitRunner, err := os.Create(
 		filepath.Join(opts.RunDir(), "junit_runner.xml"),
 	)
@@ -156,6 +160,36 @@ func RealMain(opts types.Options, d types.Deployer, tester types.Tester) (result
 		if testErr != nil {
 			return testErr
 		}
+	}
+	return nil
+}
+
+func writeVersionToMetadataJSON(opts types.Options) error {
+	// setup the json metadata writer
+	metadataJSON, err := os.Create(
+		filepath.Join(opts.RunDir(), "metadata.json"),
+	)
+	if err != nil {
+		return err
+	}
+
+	meta, err2 := metadata.NewCustomJSON(nil)
+	if err2 != nil {
+		return err2
+	}
+	if err := meta.Add("kubetest-version", os.Getenv("KUBETEST2_VERSION")); err != nil {
+		return err
+	}
+
+	if err := meta.Write(metadataJSON); err != nil {
+		return err
+	}
+
+	if err := metadataJSON.Sync(); err != nil {
+		return err
+	}
+	if err := metadataJSON.Close(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/app/cmd.go
+++ b/pkg/app/cmd.go
@@ -67,8 +67,6 @@ func runE(
 	opts.bindFlags(kubetest2Flags)
 	artifacts.MustBindFlags(kubetest2Flags)
 
-	cmd.Printf("Running deployer %s version: %s\n", deployerName, shim.GitTag)
-
 	// NOTE: unknown flags are forwarded to the deployer as arguments
 	kubetest2Flags.ParseErrorsWhitelist.UnknownFlags = true
 

--- a/pkg/app/cmd.go
+++ b/pkg/app/cmd.go
@@ -91,7 +91,6 @@ func runE(
 		if err != nil {
 			return fmt.Errorf("unable to find tester %v: %v", opts.test, err)
 		}
-		cmd.Printf("Running tester %s version: %s\n", opts.test, shim.GitTag)
 
 		// Get tester usage by running it with --help
 		var helpArgs []string

--- a/pkg/app/shim/shim.go
+++ b/pkg/app/shim/shim.go
@@ -69,7 +69,6 @@ func NewCommand() *cobra.Command {
 
 // runE implements the actual command logic
 func runE(cmd *cobra.Command, args []string) error {
-	cmd.Printf("Running %s version: %s\n", BinaryName, GitTag)
 	// there should be at least one argument (the deployer) unless the user
 	// is asking for help on the shim itself
 	if len(args) < 1 {

--- a/pkg/app/shim/shim.go
+++ b/pkg/app/shim/shim.go
@@ -102,7 +102,11 @@ func runE(cmd *cobra.Command, args []string) error {
 		usage(cmd)
 		return err
 	}
-	return process.Exec(deployer, args[1:], os.Environ())
+
+	env := os.Environ()
+	version := fmt.Sprintf("kubetest2 version %s", GitTag)
+	env = append(env, fmt.Sprintf("KUBETEST2_VERSION=%s", version))
+	return process.Exec(deployer, args[1:], env)
 }
 
 // custom help info, includes usage()

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+)
+
+type CustomJSON struct {
+	data map[string]string
+}
+
+func NewCustomJSON(from io.Reader) (*CustomJSON, error) {
+	meta := &CustomJSON{}
+	if from != nil {
+		dataBytes, err := ioutil.ReadAll(from)
+		if err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(dataBytes, &meta.data); err != nil {
+			return nil, err
+		}
+	}
+	return meta, nil
+}
+
+func (m *CustomJSON) Add(key, value string) error {
+	if m.data == nil {
+		m.data = map[string]string{}
+	}
+	if _, exists := m.data[key]; exists {
+		return fmt.Errorf("key %s already exists in the metadata", key)
+	}
+	m.data[key] = value
+	return nil
+}
+
+func (m *CustomJSON) Write(writer io.Writer) error {
+	data, err := json.Marshal(m.data)
+	if err == nil {
+		_, err = writer.Write(data)
+	}
+	return err
+}

--- a/pkg/metadata/metadata_test.go
+++ b/pkg/metadata/metadata_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestCustomJSON_AddWrite(t *testing.T) {
+	meta := CustomJSON{}
+	if err := meta.Add("foo", "bar"); err != nil {
+		t.Errorf("did not expect an error, but got: %v", err)
+	}
+	if err := meta.Add("baz", "qwe"); err != nil {
+		t.Errorf("did not expect an error, but got: %v", err)
+	}
+
+	var buff bytes.Buffer
+	if err := meta.Write(&buff); err != nil {
+		t.Errorf("did not expect an error, but got: %v", err)
+	}
+
+	actualBytes := buff.Bytes()
+
+	expectedBytes, err := json.Marshal(meta.data)
+	if err != nil {
+		t.Errorf("did not expect an error, but got: %v", err)
+	}
+	if !bytes.Equal(buff.Bytes(), expectedBytes) {
+		t.Errorf("mismatched metadata bytes, got: %v, want: %v", actualBytes, expectedBytes)
+	}
+}
+
+func TestNewCustomJSON(t *testing.T) {
+	json := `{"baz":"qwe","foo":"bar"}`
+	meta, err := NewCustomJSON(strings.NewReader(json))
+	if err != nil {
+		t.Errorf("did not expect an error, but got: %v", err)
+	}
+	expectedData := map[string]string{
+		"foo": "bar",
+		"baz": "qwe",
+	}
+	if !reflect.DeepEqual(meta.data, expectedData) {
+		t.Errorf("mismatched metadata bytes, got: %v, want: %v", meta.data, expectedData)
+	}
+}

--- a/pkg/testers/clusterloader2/cl2.go
+++ b/pkg/testers/clusterloader2/cl2.go
@@ -30,6 +30,8 @@ import (
 	suite "sigs.k8s.io/kubetest2/pkg/testers/clusterloader2/suite"
 )
 
+var GitTag string
+
 type Tester struct {
 	Suites        string `desc:"Comma separated list of standard scale testing suites e.g. load, density"`
 	TestOverrides string `desc:"Comma separated list of paths to the config override files. The latter overrides take precedence over changes in former files."`

--- a/pkg/testers/clusterloader2/cl2.go
+++ b/pkg/testers/clusterloader2/cl2.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/klog"
 
 	"sigs.k8s.io/kubetest2/pkg/exec"
+	"sigs.k8s.io/kubetest2/pkg/testers"
 	suite "sigs.k8s.io/kubetest2/pkg/testers/clusterloader2/suite"
 )
 
@@ -122,7 +123,9 @@ func (t *Tester) Execute() error {
 		fs.PrintDefaults()
 		return nil
 	}
-
+	if err := testers.WriteVersionToMetadata(GitTag); err != nil {
+		return err
+	}
 	return t.Test()
 }
 

--- a/pkg/testers/exec/exec.go
+++ b/pkg/testers/exec/exec.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/klog"
 
 	"sigs.k8s.io/kubetest2/pkg/process"
+	"sigs.k8s.io/kubetest2/pkg/testers"
 )
 
 var GitTag string
@@ -64,6 +65,9 @@ func (t *Tester) Execute() error {
 	}
 
 	t.argv = os.Args[1:]
+	if err := testers.WriteVersionToMetadata(GitTag); err != nil {
+		return err
+	}
 	return t.Test()
 }
 

--- a/pkg/testers/exec/exec.go
+++ b/pkg/testers/exec/exec.go
@@ -27,6 +27,8 @@ import (
 	"sigs.k8s.io/kubetest2/pkg/process"
 )
 
+var GitTag string
+
 type Tester struct {
 	argv []string
 }

--- a/pkg/testers/ginkgo/ginkgo.go
+++ b/pkg/testers/ginkgo/ginkgo.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/kubetest2/pkg/artifacts"
 	"sigs.k8s.io/kubetest2/pkg/build"
 	"sigs.k8s.io/kubetest2/pkg/exec"
+	"sigs.k8s.io/kubetest2/pkg/testers"
 )
 
 var GitTag string
@@ -165,6 +166,9 @@ func (t *Tester) Execute() error {
 	}
 
 	if err := t.initKubetest2Info(); err != nil {
+		return err
+	}
+	if err := testers.WriteVersionToMetadata(GitTag); err != nil {
 		return err
 	}
 	return t.Test()

--- a/pkg/testers/ginkgo/ginkgo.go
+++ b/pkg/testers/ginkgo/ginkgo.go
@@ -31,6 +31,8 @@ import (
 	"sigs.k8s.io/kubetest2/pkg/exec"
 )
 
+var GitTag string
+
 type Tester struct {
 	FlakeAttempts      int    `desc:"Make up to this many attempts to run each spec."`
 	GinkgoArgs         string `desc:"Additional arguments supported by the ginkgo binary."`

--- a/pkg/testers/metadata.go
+++ b/pkg/testers/metadata.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testers
+
+import (
+	"os"
+	"path/filepath"
+
+	"sigs.k8s.io/kubetest2/pkg/metadata"
+)
+
+func WriteVersionToMetadata(version string) error {
+	var meta *metadata.CustomJSON
+	// check existing metadata and initialize it if it exists
+	metadataPath := filepath.Join(os.Getenv("KUBETEST2_RUN_DIR"), "metadata.json")
+	if _, err := os.Stat(metadataPath); err == nil {
+		metadataJSON, err := os.Open(metadataPath)
+		if err != nil {
+			return err
+		}
+		meta, err = metadata.NewCustomJSON(metadataJSON)
+		if err != nil {
+			return err
+		}
+
+		if err := metadataJSON.Sync(); err != nil {
+			return err
+		}
+		if err := metadataJSON.Close(); err != nil {
+			return err
+		}
+	} else {
+		meta, err = metadata.NewCustomJSON(nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := meta.Add("tester-version", version); err != nil {
+		return err
+	}
+
+	metadataJSON, err := os.Create(metadataPath)
+	if err != nil {
+		return err
+	}
+	if err := meta.Write(metadataJSON); err != nil {
+		return err
+	}
+
+	if err := metadataJSON.Sync(); err != nil {
+		return err
+	}
+	if err := metadataJSON.Close(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/testers/node/node.go
+++ b/pkg/testers/node/node.go
@@ -34,6 +34,8 @@ import (
 	"sigs.k8s.io/kubetest2/pkg/exec"
 )
 
+var GitTag string
+
 const (
 	target                 = "test-e2e-node"
 	gceProjectResourceType = "gce-project"

--- a/pkg/testers/node/node.go
+++ b/pkg/testers/node/node.go
@@ -28,10 +28,11 @@ import (
 
 	"github.com/octago/sflags/gen/gpflag"
 	"k8s.io/klog"
-	"sigs.k8s.io/boskos/client"
 
+	"sigs.k8s.io/boskos/client"
 	"sigs.k8s.io/kubetest2/pkg/boskos"
 	"sigs.k8s.io/kubetest2/pkg/exec"
+	"sigs.k8s.io/kubetest2/pkg/testers"
 )
 
 var GitTag string
@@ -132,7 +133,9 @@ func (t *Tester) Execute() error {
 			}
 		}
 	}()
-
+	if err := testers.WriteVersionToMetadata(GitTag); err != nil {
+		return err
+	}
 	return t.Test()
 }
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -113,6 +113,14 @@ type DeployerWithPostTester interface {
 	PostTest(testErr error) error
 }
 
+// DeployerWithVersion allows the deployer to specify it's version
+type DeployerWithVersion interface {
+	Deployer
+
+	// Version determines the version of the deployer binary
+	Version() string
+}
+
 // Tester defines the "interface" between kubetest2 and a tester
 // The tester is executed as a separate binary during the Test() phase
 type Tester struct {


### PR DESCRIPTION
also add support for writing `metadata.json` similar to what kubetest does in existing prow jobs.

fixes: https://github.com/kubernetes-sigs/kubetest2/issues/108

For deployers:
the shim GitTag won't be present for out-of-tree providers instead inject an env `KUBETEST2_VERSION` from the shim to the deployers.

For testers:
Went the route of overwriting metadata in testers.
alternative was to enforce all testers support a `--version` flag and detect it similar to `--help`, but is unnecessarily restrictive.

/cc @BenTheElder @spiffxp 