### PR TITLE
Added flags needed for pull-kubernetes-node-e2e job

### DIFF
--- a/pkg/testers/node/node.go
+++ b/pkg/testers/node/node.go
@@ -53,6 +53,8 @@ type Tester struct {
 	BoskosAcquireTimeoutSeconds    int    `desc:"How long (in seconds) to hang on a request to Boskos to acquire a resource before erroring."`
 	BoskosHeartbeatIntervalSeconds int    `desc:"How often (in seconds) to send a heartbeat to Boskos to hold the acquired resource. 0 means no heartbeat."`
 	BoskosLocation                 string `desc:"If set, manually specifies the location of the boskos server. If unset and boskos is needed"`
+	ImageConfigFile				   string `desc:"Path to a file containing image configuration."`
+	Parallelism					   int    `desc:"The number of nodes to run in parallel."`
 
 	// boskos struct field will be non-nil when the deployer is
 	// using boskos to acquire a GCP project
@@ -69,6 +71,7 @@ func NewDefaultTester() *Tester {
 		Runtime:                     "docker",
 		BoskosLocation:              "http://boskos.test-pods.svc.cluster.local.",
 		BoskosAcquireTimeoutSeconds: 5 * 60,
+		Parallelism					 8,
 	}
 }
 
@@ -164,6 +167,9 @@ func (t *Tester) constructArgs() []string {
 		"CLOUDSDK_CORE_PROJECT=" + t.GCPProject,
 		// https://github.com/kubernetes/kubernetes/blob/96be00df69390ed41b8ec22facc43bcbb9c88aae/hack/make-rules/test-e2e-node.sh#L113
 		"ZONE=" + t.GCPZone,
+		"TEST_ARGS=" + t.TestArgs
+		"PARALLELISM=" + t.Parallelism
+		"IMAGE_CONFIG_FILE=" + t.ImageConfigFile
 	}
 	return append(defaultArgs, argsFromFlags...)
 }


### PR DESCRIPTION
Signed-off-by: Namanl2001 <namanlakhwani@gmail.com>

Added `PARALLELISM` and `IMAGE_CONFIG_FILE` in the node tester. Which are needed for [pull-kubernetes-node-e2e](https://github.com/kubernetes/test-infra/blob/3c87dfedd57e2dcad764a0d7fbb4343c7ca02a24/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml#L43-L88) job.