### PR TITLE
gke: Avoid hardcoding COS as default image type

### DIFF
--- a/kubetest2-gke/deployer/deployer.go
+++ b/kubetest2-gke/deployer/deployer.go
@@ -42,7 +42,6 @@ var GitTag string
 
 const (
 	defaultFirewallRuleAllow = "tcp:22,tcp:80,tcp:8080,tcp:30000-32767,udp:30000-32767"
-	defaultImage             = "cos"
 	defaultWindowsImage      = WindowsImageTypeLTSC
 )
 
@@ -197,7 +196,6 @@ func NewDeployer(opts types.Options) *Deployer {
 			NumClusters: 1,
 			NumNodes:    defaultNodePool.Nodes,
 			MachineType: defaultNodePool.MachineType,
-			ImageType:   defaultImage,
 			// Leave ClusterVersion as empty to use the default cluster version.
 			ClusterVersion:    "",
 			FirewallRuleAllow: defaultFirewallRuleAllow,

--- a/kubetest2-gke/deployer/deployer.go
+++ b/kubetest2-gke/deployer/deployer.go
@@ -42,7 +42,6 @@ var GitTag string
 
 const (
 	defaultFirewallRuleAllow = "tcp:22,tcp:80,tcp:8080,tcp:30000-32767,udp:30000-32767"
-	defaultWindowsImage      = WindowsImageTypeLTSC
 )
 
 const (
@@ -202,7 +201,6 @@ func NewDeployer(opts types.Options) *Deployer {
 
 			WindowsNumNodes:    defaultWindowsNodePool.Nodes,
 			WindowsMachineType: defaultWindowsNodePool.MachineType,
-			WindowsImageType:   defaultWindowsImage,
 
 			RetryableErrorPatterns: []string{gceStockoutErrorPattern},
 		},

--- a/kubetest2-gke/deployer/up.go
+++ b/kubetest2-gke/deployer/up.go
@@ -33,14 +33,6 @@ import (
 	"sigs.k8s.io/kubetest2/pkg/metadata"
 )
 
-const (
-	// WindowsImageTypeLTSC is a gcloud --image-type option for Windows LTSC image
-	WindowsImageTypeLTSC = "WINDOWS_LTSC"
-
-	// WindowsImageTypeSAC is a gcloud --image-type opotion for Windows SAC image
-	WindowsImageTypeSAC = "WINDOWS_SAC"
-)
-
 // Deployer implementation methods below
 func (d *Deployer) Up() error {
 	if err := d.Init(); err != nil {
@@ -236,7 +228,9 @@ func (d *Deployer) createWindowsNodePoolCommand(project string, cluster cluster,
 	fs = append(fs, "--cluster="+cluster.name)
 	fs = append(fs, "--project="+project)
 	fs = append(fs, locationArg)
-	fs = append(fs, "--image-type="+imageType)
+	if imageType != "" {
+		fs = append(fs, "--image-type="+imageType)
+	}
 	fs = append(fs, "--machine-type="+d.WindowsMachineType)
 	fs = append(fs, "--num-nodes="+strconv.Itoa(d.WindowsNumNodes))
 

--- a/kubetest2-gke/deployer/up.go
+++ b/kubetest2-gke/deployer/up.go
@@ -158,7 +158,9 @@ func (d *Deployer) CreateCluster(project string, cluster cluster, subNetworkArgs
 	if !d.Autopilot {
 		args = append(args, "--machine-type="+d.MachineType)
 		args = append(args, "--num-nodes="+strconv.Itoa(d.NumNodes))
-		args = append(args, "--image-type="+d.ImageType)
+		if d.ImageType != "" {
+			args = append(args, "--image-type="+d.ImageType)
+		}
 		if d.WorkloadIdentityEnabled {
 			args = append(args, fmt.Sprintf("--workload-pool=%s.svc.id.goog", project))
 		}


### PR DESCRIPTION
The default image type in GKE as of 1.19 is COS_CONTAINERD. kubetest2
gke deployer should avoid hardcoding the image and instead rely on the
default unless image is specified.