### PR TITLE
Some updates to kubetest2 gke deployer

### DIFF
--- a/kubetest2-gke/deployer/deployer.go
+++ b/kubetest2-gke/deployer/deployer.go
@@ -89,10 +89,10 @@ type ig struct {
 	uniq string
 }
 
-type cluster struct {
-	// index is the index of the cluster in the list provided via the --cluster-name flag
-	index int
-	name  string
+type Cluster struct {
+	// Index is the index of the cluster in the list provided via the --cluster-name flag
+	Index int
+	Name  string
 }
 
 type Deployer struct {
@@ -108,7 +108,7 @@ type Deployer struct {
 	// doInit helps to make sure the initialization is performed only once
 	doInit sync.Once
 	// only used for multi-project multi-cluster profile to save the project-clusters mapping
-	projectClustersLayout map[string][]cluster
+	projectClustersLayout map[string][]Cluster
 	// project -> cluster -> instance groups
 	instanceGroups map[string]map[string][]*ig
 
@@ -217,18 +217,18 @@ func (d *Deployer) VerifyLocationFlags() error {
 	return nil
 }
 
-// locationFlag builds the zone/region flag from the provided zone/region
+// LocationFlag builds the zone/region flag from the provided zone/region
 // used by gcloud commands.
-func locationFlag(regions, zones []string, retryCount int) string {
+func LocationFlag(regions, zones []string, retryCount int) string {
 	if len(zones) != 0 {
 		return "--zone=" + zones[retryCount]
 	}
 	return "--region=" + regions[retryCount]
 }
 
-// regionFromLocation computes the region from the specified zone/region
+// RegionFromLocation computes the region from the specified zone/region
 // used by some commands (such as subnets), which do not support zones.
-func regionFromLocation(regions, zones []string, retryCount int) string {
+func RegionFromLocation(regions, zones []string, retryCount int) string {
 	if len(zones) != 0 {
 		zone := zones[retryCount]
 		return zone[0:strings.LastIndex(zone, "-")]

--- a/kubetest2-gke/deployer/deployer_test.go
+++ b/kubetest2-gke/deployer/deployer_test.go
@@ -46,7 +46,7 @@ func TestLocationFlag(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		got := locationFlag(tc.regions, tc.zones, tc.retryCount)
+		got := LocationFlag(tc.regions, tc.zones, tc.retryCount)
 		if got != tc.expected {
 			t.Errorf("expected %q but got %q", tc.expected, got)
 		}
@@ -81,7 +81,7 @@ func TestRegionFromLocation(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		got := regionFromLocation(tc.regions, tc.zones, tc.retryCount)
+		got := RegionFromLocation(tc.regions, tc.zones, tc.retryCount)
 		if got != tc.expected {
 			t.Errorf("expected %q but got %q", tc.expected, got)
 		}

--- a/kubetest2-gke/deployer/dumplogs.go
+++ b/kubetest2-gke/deployer/dumplogs.go
@@ -70,7 +70,7 @@ export KUBE_NODE_OS_DISTRIBUTION='%[3]s'
 			if err := d.GetInstanceGroups(); err != nil {
 				return err
 			}
-			for _, ig := range d.instanceGroups[project][cluster.name] {
+			for _, ig := range d.instanceGroups[project][cluster.Name] {
 				filters = append(filters, fmt.Sprintf("(metadata.created-by:*%s)", ig.path))
 			}
 		}

--- a/kubetest2-gke/deployer/network_test.go
+++ b/kubetest2-gke/deployer/network_test.go
@@ -29,7 +29,7 @@ func TestPrivateClusterArgs(t *testing.T) {
 		network        string
 		accessLevel    string
 		masterIPRanges []string
-		clusterInfo    cluster
+		clusterInfo    Cluster
 		autopilot      bool
 		expected       []string
 	}{
@@ -39,7 +39,7 @@ func TestPrivateClusterArgs(t *testing.T) {
 			network:        "test-network1",
 			accessLevel:    string(no),
 			masterIPRanges: []string{"172.16.0.32/28"},
-			clusterInfo:    cluster{index: 0, name: "cluster1"},
+			clusterInfo:    Cluster{Index: 0, Name: "cluster1"},
 			expected: []string{
 				"--enable-private-nodes",
 				"--enable-ip-alias",
@@ -57,7 +57,7 @@ func TestPrivateClusterArgs(t *testing.T) {
 			network:        "test-network2",
 			accessLevel:    string(limited),
 			masterIPRanges: []string{"173.16.0.32/28"},
-			clusterInfo:    cluster{index: 0, name: "cluster2"},
+			clusterInfo:    Cluster{Index: 0, Name: "cluster2"},
 			expected: []string{
 				"--enable-private-nodes",
 				"--enable-ip-alias",
@@ -74,7 +74,7 @@ func TestPrivateClusterArgs(t *testing.T) {
 			network:        "test-network3",
 			accessLevel:    string(unrestricted),
 			masterIPRanges: []string{"173.16.0.32/28", "175.16.0.32/22"},
-			clusterInfo:    cluster{index: 1, name: "cluster3"},
+			clusterInfo:    Cluster{Index: 1, Name: "cluster3"},
 			expected: []string{
 				"--enable-private-nodes",
 				"--enable-ip-alias",
@@ -91,7 +91,7 @@ func TestPrivateClusterArgs(t *testing.T) {
 			network:        "test-network4",
 			accessLevel:    string(unrestricted),
 			masterIPRanges: []string{"173.16.0.32/28", "175.16.0.32/22"},
-			clusterInfo:    cluster{index: 1, name: "cluster3"},
+			clusterInfo:    Cluster{Index: 1, Name: "cluster3"},
 			expected: []string{
 				"--enable-private-nodes",
 				"--enable-ip-alias",
@@ -107,7 +107,7 @@ func TestPrivateClusterArgs(t *testing.T) {
 			network:        "test-network5",
 			accessLevel:    string(unrestricted),
 			masterIPRanges: []string{"173.16.0.32/28", "175.16.0.32/22"},
-			clusterInfo:    cluster{index: 0, name: "cluster1"},
+			clusterInfo:    Cluster{Index: 0, Name: "cluster1"},
 			autopilot:      true,
 			expected: []string{
 				"--enable-private-nodes",


### PR DESCRIPTION
1. Change more fields to be public to use it as a library
2. For multi-project multi-cluster topology, allow to not specify the project index in the cluster names, in which case the cluster index will be the same as the project index
3. It's not useful to print the number of firewall rules deleted, so dropping the calculation and return logic