### PR TITLE
Use gce-project to run e2e tests for kubetest2 gke deployer

### DIFF
--- a/kubetest2-gke/ci-tests/buildupdown.sh
+++ b/kubetest2-gke/ci-tests/buildupdown.sh
@@ -59,6 +59,7 @@ function main() {
 
   kubetest2 gke \
     -v 2 \
+    --boskos-resource-type gce-project \
     --num-clusters "${NUM_CLUSTERS}" \
     --num-nodes 1 \
     --zone us-central1-c,us-west1-a,us-east1-b \

--- a/kubetest2-gke/deployer/down.go
+++ b/kubetest2-gke/deployer/down.go
@@ -29,6 +29,11 @@ func (d *Deployer) Down() error {
 	if err := d.Init(); err != nil {
 		return err
 	}
+	// Nothing to clean if there is no GCP project.
+	// This edge case happens e.g. when Up fails to acquire the Boskos project.
+	if len(d.Projects) == 0 {
+		return nil
+	}
 
 	d.DeleteClusters(d.retryCount)
 


### PR DESCRIPTION
Since `gke-project` pool was removed from https://github.com/kubernetes/test-infra/pull/23880

Also fix the panic when it fails to acquire projects from Boskos - https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_kubetest2/171/pull-kubetest2-gke-up-down-singlecluster/1456054639957905408