### PR TITLE
Add support for NODE_SCOPES and KUBE_GCE_NODE_SERVICE_ACCOUNT

### DIFF
--- a/kubetest2-gce/deployer/common.go
+++ b/kubetest2-gce/deployer/common.go
@@ -176,11 +176,11 @@ func (d *deployer) buildEnv() []string {
 	// e.g. https://github.com/kubernetes/kubernetes/issues/99480
 	env = append(env, "KUBE_CONFIG_FILE=config-test.sh")
 
-	if d.NodeScopes) != "" {
+	if d.NodeScopes != "" {
 		env = append(env, fmt.Sprintf("NODE_SCOPES=%s", d.NodeScopes))
 	}
 
-	if d.NodeServiceAccount) != "" {
+	if d.NodeServiceAccount != "" {
 		env = append(env, fmt.Sprintf("KUBE_GCE_NODE_SERVICE_ACCOUNT=%s", d.NodeServiceAccount))
 	}
 

--- a/kubetest2-gce/deployer/common.go
+++ b/kubetest2-gce/deployer/common.go
@@ -176,7 +176,7 @@ func (d *deployer) buildEnv() []string {
 	// e.g. https://github.com/kubernetes/kubernetes/issues/99480
 	env = append(env, "KUBE_CONFIG_FILE=config-test.sh")
 
-	if len(d.NodeScopes) > 0 {
+	if d.NodeScopes) != "" {
 		env = append(env, fmt.Sprintf("NODE_SCOPES=%s", d.NodeScopes))
 	}
 

--- a/kubetest2-gce/deployer/common.go
+++ b/kubetest2-gce/deployer/common.go
@@ -180,7 +180,7 @@ func (d *deployer) buildEnv() []string {
 		env = append(env, fmt.Sprintf("NODE_SCOPES=%s", d.NodeScopes))
 	}
 
-	if len(d.NodeServiceAccount) > 0 {
+	if d.NodeServiceAccount) != "" {
 		env = append(env, fmt.Sprintf("KUBE_GCE_NODE_SERVICE_ACCOUNT=%s", d.NodeServiceAccount))
 	}
 

--- a/kubetest2-gce/deployer/common.go
+++ b/kubetest2-gce/deployer/common.go
@@ -176,6 +176,14 @@ func (d *deployer) buildEnv() []string {
 	// e.g. https://github.com/kubernetes/kubernetes/issues/99480
 	env = append(env, "KUBE_CONFIG_FILE=config-test.sh")
 
+	if len(d.NodeScopes) > 0 {
+		env = append(env, fmt.Sprintf("NODE_SCOPES=%s", d.NodeScopes))
+	}
+
+	if len(d.NodeServiceAccount) > 0 {
+		env = append(env, fmt.Sprintf("KUBE_GCE_NODE_SERVICE_ACCOUNT=%s", d.NodeServiceAccount))
+	}
+
 	return env
 }
 

--- a/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2-gce/deployer/deployer.go
@@ -82,6 +82,8 @@ type deployer struct {
 	RuntimeConfig               string `desc:"Sets the KUBE_RUNTIME_CONFIG environment variable during deployment."`
 	EnablePodSecurityPolicy     bool   `desc:"Sets the environment variable ENABLE_POD_SECURITY_POLICY=true during deployment."`
 	CreateCustomNetwork         bool   `desc:"Sets the environment variable CREATE_CUSTOM_NETWORK=true during deployment."`
+	NodeScopes                  string `desc:"Sets the NODE_SCOPES environment variable during deployment."`
+	NodeServiceAccount          string `desc:"Sets the KUBE_GCE_NODE_SERVICE_ACCOUNT environment variable during deployment."`
 }
 
 // pseudoUniqueSubstring returns a substring of a UUID


### PR DESCRIPTION
The NODE_SCOPES and KUBE_GCE_NODE_SERVICE_ACCOUNT are necessary to be able to create a cluster whose nodes use a specific service account as their identity. Using a specific service account, the workloads running on the nodes can authenticate with the Compute API without using service account keys (and exporting service account keys is discouraged as it is unsafe).

I tested manually that it is possible to authenticate the workloads on a cluster created by cluster/kube-up.sh if the NODE_SCOPES and KUBE_GCE_NODE_SERVICE_ACCOUNT variables are set. Now I'd like to do a similar thing with a Google-internal Prow instance and I'm not sure if I could easily test this PR on this internal instance (though this PR is a small one and it seems to me it should work fine). Please advise as I don't have much experience developing against kubetest2.