### PR TITLE
[Bug fix] Boskos release should set the resource state to dirty

### DIFF
--- a/pkg/boskos/boskos.go
+++ b/pkg/boskos/boskos.go
@@ -95,7 +95,7 @@ func startBoskosHeartbeat(boskosClient *client.Client, resource *common.Resource
 // Release releases a resource.
 func Release(client *client.Client, resourceNames []string, heartbeatClose chan struct{}) error {
 	for _, name := range resourceNames {
-		if err := client.Release(name, "free"); err != nil {
+		if err := client.Release(name, "dirty"); err != nil {
 			return fmt.Errorf("failed to release %s: %s", name, err)
 		}
 	}


### PR DESCRIPTION
To use Boskos as the GCP project rental, when releasing the project, it should reset its state to `dirty` instead of `free`, this'll allow GCP Janitor to clean up all resources in the project and reset it to `free`, so that the project can be returned to the project rental in a clean state.

/cc @MushuEE 