### PR TITLE
Allow rundir to be set with SetRunDir

### DIFF
--- a/pkg/testers/ginkgo/ginkgo.go
+++ b/pkg/testers/ginkgo/ginkgo.go
@@ -189,6 +189,10 @@ func (t *Tester) initKubetest2Info() error {
 	return nil
 }
 
+func (t *Tester) SetRunDir(dir string) {
+	t.runDir = dir
+}
+
 func NewDefaultTester() *Tester {
 	return &Tester{
 		FlakeAttempts:     1,


### PR DESCRIPTION
Kops wraps the ginkgo tester with its own tester, but doesn't has its own `Execute()` method.  This will allow the kops tester to use `KUBETEST2_RUN_DIR` as the `runDir` without much refactoring. 

See https://github.com/kubernetes/kops/pull/13217