### PR TITLE
Decouple RunDir from Artifacts

### DIFF
--- a/pkg/artifacts/paths.go
+++ b/pkg/artifacts/paths.go
@@ -18,14 +18,14 @@ package artifacts
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
-
 	"github.com/spf13/pflag"
 	"k8s.io/klog"
+	"os"
+	"path/filepath"
 )
 
 var baseDir string
+var RunDirFlag string
 
 // BaseDir returns the path to the directory where artifacts should be written
 // (including metadata files like junit_runner.xml)
@@ -35,6 +35,20 @@ func BaseDir() string {
 		def, err := defaultArtifactsDir()
 		if err != nil {
 			klog.Fatalf("failed to get default artifacts directory: %s", err)
+		}
+		d = def
+	}
+	return d
+}
+
+// RunDir returns the path to the directory used for storing all files in general
+// specific to a single run of kubetest2
+func RunDir() string {
+	d := RunDirFlag
+	if d == "" {
+		def, err := defaultRunDir()
+		if err != nil {
+			klog.Fatalf("failed to get default Run directory: %s", err)
 		}
 		d = def
 	}
@@ -60,13 +74,32 @@ func defaultArtifactsDir() (string, error) {
 	return absPath, nil
 }
 
-// BindFlags binds the artifact related flags.
+// the default is $KUBETEST2_RUN_DIR if set, otherwise ./_rundir
+// constructed as an absolute path to help the ginkgo tester because
+// for some reason it needs an absolute path to the kubeconfig
+func defaultRunDir() (string, error) {
+	if path, set := os.LookupEnv("KUBETEST2_RUN_DIR"); set {
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			return "", fmt.Errorf("failed to convert filepath from $KUBETEST2_RUN_DIR (%s) to absolute path: %s", path, err)
+		}
+		return absPath, nil
+	}
+	absPath, err := filepath.Abs("_rundir")
+	if err != nil {
+		return "", fmt.Errorf("when constructing default rundir, failed to get absolute path: %s", err)
+	}
+	return absPath, nil
+}
+
+// BindFlags binds the artifact and rundir related flags.
 func BindFlags(flags *pflag.FlagSet) error {
 	defaultArtifacts, err := defaultArtifactsDir()
 	if err != nil {
 		return err
 	}
 	flags.StringVar(&baseDir, "artifacts", defaultArtifacts, `top-level directory to put artifacts under for each kubetest2 run, defaulting to "${ARTIFACTS:-./_artifacts}". If using the ginkgo tester, this must be an absolute path.`)
+	flags.StringVar(&RunDirFlag, "rundir", "", `directory to put run related test binaries like e2e.test, ginkgo, kubectl for each kubetest2 run, defaulting to "${KUBETEST2_RUN_DIR:-./_rundir}". If using the ginkgo tester, this must be an absolute path.`)
 	return nil
 }
 
@@ -74,6 +107,6 @@ func BindFlags(flags *pflag.FlagSet) error {
 func MustBindFlags(flags *pflag.FlagSet) {
 	err := BindFlags(flags)
 	if err != nil {
-		klog.Fatalf("failed to get default artifacts directory: %s", err)
+		klog.Fatalf("failed to get default artifacts || rundir directory: %s", err)
 	}
 }

--- a/pkg/testers/ginkgo/package.go
+++ b/pkg/testers/ginkgo/package.go
@@ -73,13 +73,17 @@ func (t *Tester) AcquireTestPackage() error {
 		return err
 	}
 
-	t.kubectlPath = filepath.Join(artifacts.BaseDir(), "kubectl")
+	t.kubectlPath = filepath.Join(artifacts.RunDir(), "kubectl")
 	return t.ensureKubectl(t.kubectlPath)
 }
 
 func (t *Tester) extractBinaries(downloadPath string) error {
 	// ensure the artifacts dir
 	if err := os.MkdirAll(artifacts.BaseDir(), os.ModePerm); err != nil {
+		return err
+	}
+	// ensure the rundir
+	if err := os.MkdirAll(artifacts.RunDir(), os.ModePerm); err != nil {
 		return err
 	}
 
@@ -98,8 +102,8 @@ func (t *Tester) extractBinaries(downloadPath string) error {
 	tarReader := tar.NewReader(gzf)
 
 	// Map of paths in archive to destination paths
-	t.e2eTestPath = filepath.Join(artifacts.BaseDir(), "e2e.test")
-	t.ginkgoPath = filepath.Join(artifacts.BaseDir(), "ginkgo")
+	t.e2eTestPath = filepath.Join(artifacts.RunDir(), "e2e.test")
+	t.ginkgoPath = filepath.Join(artifacts.RunDir(), "ginkgo")
 	extract := map[string]string{
 		"kubernetes/test/bin/e2e.test": t.e2eTestPath,
 		"kubernetes/test/bin/ginkgo":   t.ginkgoPath,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -60,6 +60,8 @@ type Options interface {
 	RunID() string
 	// RunDir returns the directory to put run-specific output files.
 	RunDir() string
+	// if this is true, kubetest2 will copy the RunDIR to ARTIFACTS
+	RundirInArtifacts() bool
 }
 
 // Deployer defines the interface between kubetest and a deployer


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/kubetest2/issues/98
This change separates RunDir from Artifacts and introduces a flag `cp-rundir-to-artifacts` for intentionally copying binaries/ metadata to artifacts.