### PR TITLE
Added a new flag --update-latest-green-marker to the GKE deployer. 

### DIFF
--- a/kubetest2-gke/deployer/build/gke_make.go
+++ b/kubetest2-gke/deployer/build/gke_make.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/kubetest2-gke/deployer/build/gke_make.go
+++ b/kubetest2-gke/deployer/build/gke_make.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"regexp"
 	"strings"
 
 	"k8s.io/klog"
 
+	util "sigs.k8s.io/kubetest2/kubetest2-gke/deployer/utils"
 	"sigs.k8s.io/kubetest2/pkg/build"
 	"sigs.k8s.io/kubetest2/pkg/exec"
 )
@@ -40,11 +40,8 @@ const (
 
 const (
 	// GKEMakeStrategy builds and stages using the gke_make build
-	GKEMakeStrategy build.BuildAndStageStrategy = "gke_make"
-)
-
-var (
-	gkeMinorVersionRegex = regexp.MustCompile(`^v(\d\.\d+).*$`)
+	GKEMakeStrategy         build.BuildAndStageStrategy = "gke_make"
+	latestBuildMarkerPrefix string                      = "latest"
 )
 
 type GKEMake struct {
@@ -120,21 +117,8 @@ func (gmb *GKEMake) Stage(version string) error {
 	}
 
 	if gmb.UpdateLatest {
-		m := gkeMinorVersionRegex.FindStringSubmatch(version)
-		var fName string
-		if len(m) < 2 {
-			klog.Warningf("can't find the minor version of %s, defaulting to latest.txt", version)
-			fName = "latest.txt"
-		} else {
-			minor := m[1]
-			fName = fmt.Sprintf("latest-%s.txt", minor)
-		}
-		pushCmd := fmt.Sprintf("gsutil -h 'Content-Type:text/plain' cp - %s/%s", gmb.StageLocation, fName)
-		cmd := exec.RawCommand(pushCmd)
-		cmd.SetStdin(strings.NewReader(version))
-		exec.SetOutput(cmd, os.Stdout, os.Stderr)
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to upload the latest version number: %s", err)
+		if err := util.StageGKEBuildMarker(version, gmb.StageLocation, latestBuildMarkerPrefix); err != nil {
+			return fmt.Errorf("error during build marker staging: %s", err)
 		}
 	}
 

--- a/kubetest2-gke/deployer/options/build.go
+++ b/kubetest2-gke/deployer/options/build.go
@@ -26,8 +26,9 @@ import (
 )
 
 type BuildOptions struct {
-	CommonBuildOptions *build.Options
-	BuildScript        string `flag:"~build-script" desc:"Only used with the gke_make build. Absolute path to the gke_make build script."`
+	CommonBuildOptions      *build.Options
+	UpdateLatestGreenMarker bool   `flag:"~update-latest-green-marker" desc:"When set to true, will update the latest-green-x.y.txt marker on GCS."`
+	BuildScript             string `flag:"~build-script" desc:"Only used with the gke_make build. Absolute path to the gke_make build script."`
 }
 
 var _ build.Builder = &BuildOptions{}

--- a/kubetest2-gke/deployer/post_tester.go
+++ b/kubetest2-gke/deployer/post_tester.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import (
+	"fmt"
+
+	util "sigs.k8s.io/kubetest2/kubetest2-gke/deployer/utils"
+)
+
+var (
+	greenMarkerPrefix = "latest-green"
+)
+
+// PostTest will check if there's any error in the test. If there's no
+// error in the test, and the --update-latest-green-marker is set to true,
+// this method will stage the build marker to the GCS bucket.
+func (d *Deployer) PostTest(testErr error) error {
+	if testErr != nil || !d.BuildOptions.UpdateLatestGreenMarker {
+		return nil
+	}
+	// If we are here, that means the new build passes the smoke test.
+	if err := util.StageGKEBuildMarker(d.ClusterVersion, d.CommonBuildOptions.StageLocation, greenMarkerPrefix); err != nil {
+		return fmt.Errorf("error during green build marker staging: %s", err)
+	}
+	return nil
+}

--- a/kubetest2-gke/deployer/utils/util.go
+++ b/kubetest2-gke/deployer/utils/util.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"k8s.io/klog"
+	"sigs.k8s.io/kubetest2/pkg/exec"
+)
+
+var (
+	gkeMinorVersionRegex = regexp.MustCompile(`^v(\d\.\d+).*$`)
+)
+
+// StageGKEBuildMarker stages the build marker to the stage location.
+func StageGKEBuildMarker(version, stageLocation, markerPrefix string) error {
+	m := gkeMinorVersionRegex.FindStringSubmatch(version)
+	var fName string
+	if len(m) < 2 {
+		klog.Warningf("can't find the minor version of %s, defaulting to latest.txt", version)
+		fName = fmt.Sprintf("%s.txt", markerPrefix)
+	} else {
+		minor := m[1]
+		fName = fmt.Sprintf("%s-%s.txt", markerPrefix, minor)
+	}
+	pushCmd := fmt.Sprintf("gsutil -h 'Content-Type:text/plain' cp - %s/%s", stageLocation, fName)
+	cmd := exec.RawCommand(pushCmd)
+	cmd.SetStdin(strings.NewReader(version))
+	exec.SetOutput(cmd, os.Stdout, os.Stderr)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to upload the latest version number: %s", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Changed the build marker staging logic for the GKE Deployer so that it only gets staged to GCS after the build / test is completed successfully.