### PR TITLE
support creating private GKE Autopilot clusters

### DIFF
--- a/kubetest2-gke/deployer/network.go
+++ b/kubetest2-gke/deployer/network.go
@@ -454,13 +454,17 @@ func removeHostServiceAgentUserRole(projects []string) error {
 
 // This function returns the args required for creating a private cluster.
 // Reference: https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#top_of_page
-func getPrivateClusterArgs(projects []string, network, accessLevel string, masterIPRanges []string, clusterInfo cluster) []string {
+func getPrivateClusterArgs(projects []string, network, accessLevel string, masterIPRanges []string, clusterInfo cluster, autopilot bool) []string {
 	common := []string{
-		"--enable-ip-alias",
 		"--enable-private-nodes",
-		"--no-enable-basic-auth",
-		"--master-ipv4-cidr=" + masterIPRanges[clusterInfo.index],
-		"--no-issue-client-certificate",
+	}
+	// GKE in Autopilot mode does not support certain flags - https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters
+	if !autopilot {
+		common = append(common,
+			"--enable-ip-alias",
+			"--no-enable-basic-auth",
+			"--master-ipv4-cidr="+masterIPRanges[clusterInfo.index],
+			"--no-issue-client-certificate")
 	}
 
 	// For multi-project profile, it'll be using the shared vpc, which creates subnets before cluster creation.

--- a/kubetest2-gke/deployer/network_test.go
+++ b/kubetest2-gke/deployer/network_test.go
@@ -30,6 +30,7 @@ func TestPrivateClusterArgs(t *testing.T) {
 		accessLevel    string
 		masterIPRanges []string
 		clusterInfo    cluster
+		autopilot      bool
 		expected       []string
 	}{
 		{
@@ -40,8 +41,8 @@ func TestPrivateClusterArgs(t *testing.T) {
 			masterIPRanges: []string{"172.16.0.32/28"},
 			clusterInfo:    cluster{index: 0, name: "cluster1"},
 			expected: []string{
-				"--enable-ip-alias",
 				"--enable-private-nodes",
+				"--enable-ip-alias",
 				"--no-enable-basic-auth",
 				"--master-ipv4-cidr=172.16.0.32/28",
 				"--no-issue-client-certificate",
@@ -58,8 +59,8 @@ func TestPrivateClusterArgs(t *testing.T) {
 			masterIPRanges: []string{"173.16.0.32/28"},
 			clusterInfo:    cluster{index: 0, name: "cluster2"},
 			expected: []string{
-				"--enable-ip-alias",
 				"--enable-private-nodes",
+				"--enable-ip-alias",
 				"--no-enable-basic-auth",
 				"--master-ipv4-cidr=173.16.0.32/28",
 				"--no-issue-client-certificate",
@@ -75,8 +76,8 @@ func TestPrivateClusterArgs(t *testing.T) {
 			masterIPRanges: []string{"173.16.0.32/28", "175.16.0.32/22"},
 			clusterInfo:    cluster{index: 1, name: "cluster3"},
 			expected: []string{
-				"--enable-ip-alias",
 				"--enable-private-nodes",
+				"--enable-ip-alias",
 				"--no-enable-basic-auth",
 				"--master-ipv4-cidr=175.16.0.32/22",
 				"--no-issue-client-certificate",
@@ -92,11 +93,25 @@ func TestPrivateClusterArgs(t *testing.T) {
 			masterIPRanges: []string{"173.16.0.32/28", "175.16.0.32/22"},
 			clusterInfo:    cluster{index: 1, name: "cluster3"},
 			expected: []string{
-				"--enable-ip-alias",
 				"--enable-private-nodes",
+				"--enable-ip-alias",
 				"--no-enable-basic-auth",
 				"--master-ipv4-cidr=175.16.0.32/22",
 				"--no-issue-client-certificate",
+				"--no-enable-master-authorized-networks",
+			},
+		},
+		{
+			desc:           "multiple flags are not needed for GKE Autopilot private clusters",
+			projects:       []string{"project1"},
+			network:        "test-network5",
+			accessLevel:    string(unrestricted),
+			masterIPRanges: []string{"173.16.0.32/28", "175.16.0.32/22"},
+			clusterInfo:    cluster{index: 0, name: "cluster1"},
+			autopilot:      true,
+			expected: []string{
+				"--enable-private-nodes",
+				"--create-subnetwork=name=test-network5-cluster1",
 				"--no-enable-master-authorized-networks",
 			},
 		},
@@ -106,7 +121,7 @@ func TestPrivateClusterArgs(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(st *testing.T) {
 			st.Parallel()
-			actual := getPrivateClusterArgs(tc.projects, tc.network, tc.accessLevel, tc.masterIPRanges, tc.clusterInfo)
+			actual := getPrivateClusterArgs(tc.projects, tc.network, tc.accessLevel, tc.masterIPRanges, tc.clusterInfo, tc.autopilot)
 			if diff := cmp.Diff(actual, tc.expected); diff != "" {
 				st.Error("Got private cluster args (-want, +got) =", diff)
 			}

--- a/kubetest2-gke/deployer/up.go
+++ b/kubetest2-gke/deployer/up.go
@@ -136,7 +136,7 @@ func (d *Deployer) isRetryableError(err error) bool {
 func (d *Deployer) CreateCluster(project string, cluster cluster, subNetworkArgs []string, locationArg string) error {
 	privateClusterArgs := []string{}
 	if d.PrivateClusterAccessLevel != "" {
-		privateClusterArgs = getPrivateClusterArgs(d.Projects, d.Network, d.PrivateClusterAccessLevel, d.privateClusterMasterIPRangesInternal[d.retryCount], cluster)
+		privateClusterArgs = getPrivateClusterArgs(d.Projects, d.Network, d.PrivateClusterAccessLevel, d.privateClusterMasterIPRangesInternal[d.retryCount], cluster, d.Autopilot)
 	}
 	// Create the cluster
 	args := d.createCommand()


### PR DESCRIPTION
Currently creating Autopilot private clusters will give an error since `--enable-ip-alias` is not supported with Autopilot. Change the command to use the ones suggested in the [official docs](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters).