### PR TITLE
Set up GoReleaser to make releases for tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,27 @@
+---
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - name: Release
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # kubetest2 default artifacts
 _artifacts/
 bin/
+dist/
 
 # VisualStudio Code specific files
 .vscode/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,58 @@
+project_name: kubetest2
+
+before:
+  hooks:
+    - go mod tidy
+
+build: &build
+  env:
+    - CGO_ENABLED=0
+  goos: [linux, darwin, windows]
+  goarch: [amd64, arm64]
+
+builds:
+  - <<: *build
+    main: .
+    id: kubetest2
+  - <<: *build
+    main: ./kubetest2-gce
+    id: kubetest2-gce
+    binary: kubetest2-gce
+  - <<: *build
+    main: ./kubetest2-gke
+    id: kubetest2-gke
+    binary: kubetest2-gke
+  - <<: *build
+    main: ./kubetest2-kind
+    id: kubetest2-kind
+    binary: kubetest2-kind
+  - <<: *build
+    main: ./kubetest2-noop
+    id: kubetest2-noop
+    binary: kubetest2-noop
+  - <<: *build
+    main: ./kubetest2-tester-clusterloader2
+    id: kubetest2-tester-clusterloader2
+    binary: kubetest2-tester-clusterloader2
+  - <<: *build
+    main: ./kubetest2-tester-exec
+    id: kubetest2-tester-exec
+    binary: kubetest2-tester-exec
+  - <<: *build
+    main: ./kubetest2-tester-ginkgo
+    id: kubetest2-tester-ginkgo
+    binary: kubetest2-tester-ginkgo
+  - <<: *build
+    main: ./kubetest2-tester-node
+    id: kubetest2-tester-node
+    binary: kubetest2-tester-node
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  use: github

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ SHELL:=env PATH=$(subst $(SPACE),\$(SPACE),$(PATH)) $(SHELL)
 # flags for reproducible go builds
 BUILD_FLAGS?=-trimpath -ldflags="-buildid="
 
+KERNEL?=$(shell uname -s)
+MACHINE?=$(shell uname -m)
+GORELEASER_BIN?=https://github.com/goreleaser/goreleaser/releases/download/v1.9.0/goreleaser_$(KERNEL)_$(MACHINE).tar.gz
+
 build-all:
 	go build -v $(BUILD_FLAGS) ./...
 
@@ -120,5 +124,15 @@ unit:
 
 verify:
 	$(MAKE) -j lint shellcheck unit tidy boilerplate
+
+snapshot: bin/goreleaser
+	@bin/goreleaser --snapshot --rm-dist
+
+bin/goreleaser:
+	@mkdir -p bin
+	@curl -sL $(GORELEASER_BIN) | tar xzf - -C bin
+	@chmod +x bin/goreleaser
+	@rm -rf bin/LICENSE.md bin/README.md bin/completions bin/manpages
+
 
 .PHONY: build-all install install-deployer-% install-tester-% install-all ci-binaries push-ci-binaries quick-verify clean-output clean verify lint shellcheck

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,9 +1,28 @@
 # Release Process
 
-The Kubernetes Template Project is released on an as-needed basis. The process is as follows:
+This project uses [GoReleaser] to manage releases. This allows for automated changelog creation (in the release notes)
+and uploading of platform specific archives.
 
-1. An issue is proposing a new release with a changelog since the last release
-1. All [OWNERS](OWNERS) must LGTM this release
-1. An OWNER runs `git tag -s $VERSION` and inserts the changelog and pushes the tag with `git push $VERSION`
-1. The release issue is closed
-1. An announcement email is sent to `kubernetes-dev@googlegroups.com` with the subject `[ANNOUNCE] kubernetes-template-project $VERSION is released`
+This is handled via a GitHub action (_see .github/workflows/release.yaml_). In order to work it requires a repo owner to
+create a GitHub Token with the `repo` scope and store that as a repository secret called `GH_RELEASE_TOKEN`.
+
+## Cutting a New Release
+
+Make sure you're on an up to date master, and run the following:
+
+* Create a new tag `git tag -s v<VERSION>`
+* Push to GitHub `git push origin v<VERSION>`
+* [GoReleaser] will take care of creating the release, adding the changelog, and attaching the binaries.
+* Send an announcement email to `kubernetes-dev@googlegroups.com` with the subject `[ANNOUNCE] kubetest2 v<VERSION> is
+	released`.
+
+## Local Snapshots
+
+Sometimes you want to verify the builds before cutting a release. This can be done locally by running:
+
+    make snapshot
+
+This will build a snapshot release (`v<VERSION+PATCH>-next`) locally and put all of the files in _./dist_. This is used
+for local testing and therefore the dist directory is git ignored.
+
+[GoReleaser]: https://goreleaser.com/


### PR DESCRIPTION
Related: #17

Adding [GoReleaser](https://goreleaser.com/) to handle generating
releases for tags. This will make it so that cutting releases is as
simple as pushing a tag. The result will be a release which includes the
changelog, binaries for Linux/Windows/Darwin, as well as the checksums
for each of the archives.

To see what this looks like, I've created a dummy release on my fork.
Because this is the first release, the changelog is massive, but going
forward it should be a little more reasonable.

Sample release:
https://github.com/pseudomuto/kubetest2/releases/tag/v0.1.0

I've added some light details about how it works in RELEASE.md as well
as the one-time setup step required to make it work (A limited scope
GitHub token).