### PR TITLE
Add support for MASTER_SIZE and NODE_SIZE in gce deployer

### DIFF
--- a/kubetest2-gce/deployer/common.go
+++ b/kubetest2-gce/deployer/common.go
@@ -137,9 +137,12 @@ func (d *deployer) buildEnv() []string {
 	// but log-dump does not, set it explicitly here for maximum consistency
 	env = append(env, fmt.Sprintf("KUBE_GCE_NETWORK=%s", d.network))
 
-	// Pass through number of nodes and associated IP range. In the future,
-	// IP range will be configurable.
+	// NUM_NODES is used by kube-up.sh script to decide what is expected shape
+	// of the cluster. It's already set on default on 3.
 	env = append(env, fmt.Sprintf("NUM_NODES=%d", d.NumNodes))
+
+	// Pass through associated IP range. In the future, IP range will be
+	// configurable.
 	env = append(env, fmt.Sprintf("CLUSTER_IP_RANGE=%s", getClusterIPRange(d.NumNodes)))
 
 	// NETWORK has to be manually specified to ensure created firewall rules
@@ -160,6 +163,16 @@ func (d *deployer) buildEnv() []string {
 
 	if d.CreateCustomNetwork {
 		env = append(env, "CREATE_CUSTOM_NETWORK=true")
+	}
+
+	// MASTER_SIZE and NODE_SIZE are used by kube-up script to decide on the
+	// shape of the cluster. We want to overwrite them only when they are set.
+	// Otherwise, let's use script default.
+	if d.MasterSize != "" {
+		env = append(env, fmt.Sprintf("MASTER_SIZE=%s", d.MasterSize))
+	}
+	if d.NodeSize != "" {
+		env = append(env, fmt.Sprintf("NODE_SIZE=%s", d.NodeSize))
 	}
 
 	// KUBECTL_PATH points to the kubectl existing in $PATH

--- a/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2-gce/deployer/deployer.go
@@ -84,6 +84,9 @@ type deployer struct {
 	CreateCustomNetwork         bool   `desc:"Sets the environment variable CREATE_CUSTOM_NETWORK=true during deployment."`
 	NodeScopes                  string `desc:"Sets the NODE_SCOPES environment variable during deployment."`
 	NodeServiceAccount          string `desc:"Sets the KUBE_GCE_NODE_SERVICE_ACCOUNT environment variable during deployment."`
+
+	MasterSize string `desc:"Sets the MASTER_SIZE environment variable during deployment."`
+	NodeSize   string `desc:"Sets the NODE_SIZE environment variable during deployment."`
 }
 
 // pseudoUniqueSubstring returns a substring of a UUID


### PR DESCRIPTION
As found out in kubernetes/test-infra#26662 / kubernetes/cloud-provider-gcp#341 kubetest2 does not support env variables set on container level.

Adding needed explicit flags to configuration.