### PR TITLE
Switch to golang native error wrapping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/google/uuid v1.1.4
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/octago/sflags v0.2.0
-	github.com/pkg/errors v0.9.1
 	github.com/pkg/math v0.0.0-20141027224758-f2ed9e40e245
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/kubetest2/pkg/artifacts"
@@ -83,7 +82,7 @@ func RealMain(opts types.Options, d types.Deployer, tester types.Tester) (result
 		filepath.Join(artifacts.BaseDir(), "junit_runner.xml"),
 	)
 	if err != nil {
-		return errors.Wrap(err, "could not create runner output")
+		return fmt.Errorf("could not create runner output: %w", err)
 	}
 	writer := metadata.NewWriter("kubetest2", junitRunner)
 

--- a/pkg/app/cmd.go
+++ b/pkg/app/cmd.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -120,10 +119,10 @@ func runE(
 	// sanity check that the deployer did not register any identical flags
 	deployerFlags.VisitAll(func(f *pflag.Flag) {
 		if kubetest2Flags.Lookup(f.Name) != nil {
-			panic(errors.Errorf("kubetest2 common flag %#v re-registered by deployer", f.Name))
+			panic(fmt.Errorf("kubetest2 common flag %#v re-registered by deployer", f.Name))
 		}
 		if f.Shorthand != "" && kubetest2Flags.ShorthandLookup(f.Shorthand) != nil {
-			panic(errors.Errorf("kubetest2 common shorthand flag %#v re-registered by deployer", f.Shorthand))
+			panic(fmt.Errorf("kubetest2 common shorthand flag %#v re-registered by deployer", f.Shorthand))
 		}
 	})
 

--- a/pkg/app/shim/deployers.go
+++ b/pkg/app/shim/deployers.go
@@ -23,8 +23,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // FindDeployer locates the binary implementing the named deployer
@@ -33,7 +31,7 @@ func FindDeployer(name string) (path string, err error) {
 	binary := fmt.Sprintf("%s-%s", BinaryName, name)
 	path, err = exec.LookPath(binary)
 	if err != nil {
-		return "", errors.Errorf("%#v not found in PATH, could not locate %#v deployer", binary, name)
+		return "", fmt.Errorf("%#v not found in PATH, could not locate %#v deployer", binary, name)
 	}
 	return path, err
 }

--- a/pkg/app/shim/testers.go
+++ b/pkg/app/shim/testers.go
@@ -23,8 +23,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // FindTester locates the binary implementing the named tester
@@ -33,7 +31,7 @@ func FindTester(name string) (path string, err error) {
 	binary := fmt.Sprintf("%s-tester-%s", BinaryName, name)
 	path, err = exec.LookPath(binary)
 	if err != nil {
-		return "", errors.Errorf("%#v not found in PATH, could not locate %#v tester", binary, name)
+		return "", fmt.Errorf("%#v not found in PATH, could not locate %#v tester", binary, name)
 	}
 	return path, err
 }

--- a/pkg/build/krel.go
+++ b/pkg/build/krel.go
@@ -21,7 +21,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/pkg/errors"
 	rbuild "k8s.io/release/pkg/build"
 )
 
@@ -47,18 +46,19 @@ func (rpb *Krel) Stage(version string) error {
 		return fmt.Errorf("invalid stage location: %v. Use gs://<bucket>/<ci|devel>/<optional-suffix>", rpb.StageLocation)
 	}
 
-	return errors.Wrap(
-		rbuild.NewInstance(&rbuild.Options{
-			Bucket:          mat[1],
-			GCSRoot:         mat[3],
-			AllowDup:        true,
-			CI:              mat[2] == "ci",
-			NoUpdateLatest:  !rpb.UpdateLatest,
-			Registry:        rpb.ImageLocation,
-			Version:         version,
-			StageExtraFiles: rpb.StageExtraFiles,
-			RepoRoot:        rpb.RepoRoot,
-		}).Push(),
-		"stage via krel push",
-	)
+	if err := rbuild.NewInstance(&rbuild.Options{
+		Bucket:          mat[1],
+		GCSRoot:         mat[3],
+		AllowDup:        true,
+		CI:              mat[2] == "ci",
+		NoUpdateLatest:  !rpb.UpdateLatest,
+		Registry:        rpb.ImageLocation,
+		Version:         version,
+		StageExtraFiles: rpb.StageExtraFiles,
+		RepoRoot:        rpb.RepoRoot,
+	}).Push(); err != nil {
+
+		return fmt.Errorf("stage via krel push: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
We now use the native error wrapping support since `github.com/pkg/errors` is read-only.