### PR TITLE
Update ginkgo flags

### DIFF
--- a/pkg/testers/ginkgo/ginkgo.go
+++ b/pkg/testers/ginkgo/ginkgo.go
@@ -65,10 +65,11 @@ func (t *Tester) Test() error {
 	e2eTestArgs := []string{
 		"--kubeconfig=" + t.kubeconfigPath,
 		"--kubectl-path=" + t.kubectlPath,
-		"--ginkgo.flakeAttempts=" + strconv.Itoa(t.FlakeAttempts),
+		"--ginkgo.flake-attempts=" + strconv.Itoa(t.FlakeAttempts),
 		"--ginkgo.skip=" + t.SkipRegex,
 		"--ginkgo.focus=" + t.FocusRegex,
 		"--report-dir=" + artifacts.BaseDir(),
+		"--ginkgo.timeout=" + "24h",
 	}
 	extraE2EArgs, err := shellquote.Split(t.TestArgs)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: leonardpahlke <leonard.pahlke@googlemail.com>

Update ginkgo flags to work with ginkgo 2.0 (see [migration guide](https://onsi.github.io/ginkgo/MIGRATING_TO_V2))

/cc @aojea @chendave

see also this testgrid issue that should be fixed https://github.com/kubernetes/kubernetes/issues/111072

/kind cleanup
/kind deprecation
