### PR TITLE
revert naming of FlakeAttempts

### DIFF
--- a/pkg/testers/ginkgo/ginkgo.go
+++ b/pkg/testers/ginkgo/ginkgo.go
@@ -65,7 +65,7 @@ func (t *Tester) Test() error {
 	e2eTestArgs := []string{
 		"--kubeconfig=" + t.kubeconfigPath,
 		"--kubectl-path=" + t.kubectlPath,
-		"--ginkgo.flake-attempts=" + strconv.Itoa(t.FlakeAttempts),
+		"--ginkgo.flakeAttempts=" + strconv.Itoa(t.FlakeAttempts),
 		"--ginkgo.skip=" + t.SkipRegex,
 		"--ginkgo.focus=" + t.FocusRegex,
 		"--report-dir=" + artifacts.BaseDir(),

--- a/pkg/testers/ginkgo/ginkgo.go
+++ b/pkg/testers/ginkgo/ginkgo.go
@@ -69,7 +69,6 @@ func (t *Tester) Test() error {
 		"--ginkgo.skip=" + t.SkipRegex,
 		"--ginkgo.focus=" + t.FocusRegex,
 		"--report-dir=" + artifacts.BaseDir(),
-		"--ginkgo.timeout=" + "24h",
 	}
 	extraE2EArgs, err := shellquote.Split(t.TestArgs)
 	if err != nil {


### PR DESCRIPTION
premature change of naming, ginkgo v2 is not running when kubetest2 installed from scratch