### PR TITLE
synchronize systemout

### DIFF
--- a/pkg/process/junitexec.go
+++ b/pkg/process/junitexec.go
@@ -57,8 +57,11 @@ func execJUnit(cmd *exec.Cmd, env []string) error {
 	cmd.Stdin = os.Stdin
 	// ensure we also capture output
 	var systemout bytes.Buffer
-	cmd.Stdout = io.MultiWriter(&systemout, os.Stdout)
-	cmd.Stderr = io.MultiWriter(&systemout, os.Stderr)
+	syncSystemOut := &mutexWriter{
+		writer: &systemout,
+	}
+	cmd.Stdout = io.MultiWriter(syncSystemOut, os.Stdout)
+	cmd.Stderr = io.MultiWriter(syncSystemOut, os.Stderr)
 
 	// actually execute, return a JUnit error if the command errors
 	if err := execCmdWithSignals(cmd); err != nil {

--- a/pkg/process/mutexwriter.go
+++ b/pkg/process/mutexwriter.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package process
+
+import (
+	"io"
+	"sync"
+)
+
+// mutexWriter is a simple synchronized wrapper around an io.Writer
+type mutexWriter struct {
+	writer io.Writer
+	mu     sync.Mutex
+}
+
+func (m *mutexWriter) Write(b []byte) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.writer.Write(b)
+}


### PR DESCRIPTION
fixes #210 

NOTE: we don't bother synchronizing `.String()` because the process is errored and dead when we're reading it.