### PR TITLE
place metadata.json in artifacts

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -68,7 +68,7 @@ func RealMain(opts types.Options, d types.Deployer, tester types.Tester) (result
 		return err
 	}
 
-	if err := writeVersionToMetadataJSON(opts, d); err != nil {
+	if err := writeVersionToMetadataJSON(d); err != nil {
 		return err
 	}
 
@@ -200,10 +200,10 @@ func RealMain(opts types.Options, d types.Deployer, tester types.Tester) (result
 	return nil
 }
 
-func writeVersionToMetadataJSON(opts types.Options, d types.Deployer) error {
+func writeVersionToMetadataJSON(d types.Deployer) error {
 	// setup the json metadata writer
 	metadataJSON, err := os.Create(
-		filepath.Join(opts.RunDir(), "metadata.json"),
+		filepath.Join(artifacts.BaseDir(), "metadata.json"),
 	)
 	if err != nil {
 		return err

--- a/pkg/testers/metadata.go
+++ b/pkg/testers/metadata.go
@@ -20,13 +20,14 @@ import (
 	"os"
 	"path/filepath"
 
+	"sigs.k8s.io/kubetest2/pkg/artifacts"
 	"sigs.k8s.io/kubetest2/pkg/metadata"
 )
 
 func WriteVersionToMetadata(version string) error {
 	var meta *metadata.CustomJSON
 	// check existing metadata and initialize it if it exists
-	metadataPath := filepath.Join(os.Getenv("KUBETEST2_RUN_DIR"), "metadata.json")
+	metadataPath := filepath.Join(artifacts.BaseDir(), "metadata.json")
 	if _, err := os.Stat(metadataPath); err == nil {
 		metadataJSON, err := os.Open(metadataPath)
 		if err != nil {


### PR DESCRIPTION
This allows its contents to end up in the `finished.json` produced by prow's pod-utils

Where prow's pod-utils look: https://github.com/kubernetes/test-infra/blob/5ca3a768c08715f87283ece56bc2f13ac62827cf/prow/pod-utils/decorate/podspec.go#L525-L531

The code that places it into `finished.json`: https://github.com/kubernetes/test-infra/blob/41e9ad5a3e2f816e048e46b71c4716e11ba75650/prow/sidecar/run.go#L127-L130