### PR TITLE
fail when no build script can be found

### DIFF
--- a/kubetest2-gke/deployer/options/build.go
+++ b/kubetest2-gke/deployer/options/build.go
@@ -17,9 +17,8 @@ limitations under the License.
 package options
 
 import (
+	"fmt"
 	"os"
-
-	"k8s.io/klog/v2"
 
 	gkeBuild "sigs.k8s.io/kubetest2/kubetest2-gke/deployer/build"
 	"sigs.k8s.io/kubetest2/pkg/build"
@@ -37,21 +36,20 @@ var _ build.Stager = &BuildOptions{}
 func (bo *BuildOptions) Validate() error {
 	if bo.CommonBuildOptions.Strategy == string(gkeBuild.GKEMakeStrategy) {
 		if bo.BuildScript != "" {
-			if _, err := os.Stat(bo.BuildScript); err == nil {
-				gkeMake := &gkeBuild.GKEMake{
-					RepoRoot:      bo.CommonBuildOptions.RepoRoot,
-					BuildScript:   bo.BuildScript,
-					VersionSuffix: bo.CommonBuildOptions.VersionSuffix,
-					StageLocation: bo.CommonBuildOptions.StageLocation,
-					UpdateLatest:  bo.CommonBuildOptions.UpdateLatest,
-				}
-				bo.CommonBuildOptions.Builder = gkeMake
-				bo.CommonBuildOptions.Stager = gkeMake
-				return nil
+			if _, err := os.Stat(bo.BuildScript); err != nil {
+				return fmt.Errorf("failed to validate --build-script, required with --strategy=gke_make: %w", err)
 			}
+			gkeMake := &gkeBuild.GKEMake{
+				RepoRoot:      bo.CommonBuildOptions.RepoRoot,
+				BuildScript:   bo.BuildScript,
+				VersionSuffix: bo.CommonBuildOptions.VersionSuffix,
+				StageLocation: bo.CommonBuildOptions.StageLocation,
+				UpdateLatest:  bo.CommonBuildOptions.UpdateLatest,
+			}
+			bo.CommonBuildOptions.Builder = gkeMake
+			bo.CommonBuildOptions.Stager = gkeMake
+			return nil
 		}
-		klog.Warningf("failed to validate --build-script, required with --strategy=gke_make; falling back to --strategy=make")
-		bo.CommonBuildOptions.Strategy = string(build.MakeStrategy)
 	}
 	return bo.CommonBuildOptions.Validate()
 }


### PR DESCRIPTION
Currently, if a missing build-script is passed, it's ignored at the make type switch back to the default make strategy.

This lets the build complete successfully --- but the resulting artifacts can't be used to make a cluster, and the reasons are mysterious and not at all obviously related to the build process (currently, there is hurl setup that needs to be done, and if it is not, then the scripts that are uploaded to gce instance metadata are too large and instances fail to create).

I think it's better to fail obviously if the build script is missing than to create a non-functional build.