### PR TITLE
dump cluster logs to artifacts dir instead of run dir

### DIFF
--- a/kubetest2-gce/ci-tests/buildupdown.sh
+++ b/kubetest2-gce/ci-tests/buildupdown.sh
@@ -28,6 +28,17 @@ make install-deployer-gce
 # currently equivalent to /home/prow/go/src/github.com/kubernetes/cloud-provider-gcp
 K_REPO_ROOT="${REPO_ROOT}/../../kubernetes/cloud-provider-gcp"
 
+# TODO(spiffxp): remove this when cloudprovider-gcp has a .bazelversion file
+export USE_BAZEL_VERSION=5.3.0
+# TODO(spiffxp): remove this when gce-build-up-down job updated to do this,
+#                or when bazel 5.3.0 is preinstalled on kubekins image
+if [ "${CI}" == "true" ]; then
+  go install github.com/bazelbuild/bazelisk@latest
+  mkdir -p /tmp/use-bazelisk
+  ln -s "$(go env GOPATH)/bin/bazelisk" /tmp/use-bazelisk/bazel
+  export PATH="/tmp/use-bazelisk:${PATH}"
+fi
+
 kubetest2 gce \
             -v 2 \
             --repo-root "$K_REPO_ROOT" \

--- a/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2-gce/deployer/deployer.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/boskos/client"
 
 	"sigs.k8s.io/kubetest2/kubetest2-gce/deployer/options"
+	"sigs.k8s.io/kubetest2/pkg/artifacts"
 	"sigs.k8s.io/kubetest2/pkg/build"
 	"sigs.k8s.io/kubetest2/pkg/types"
 )
@@ -122,7 +123,7 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 			},
 		},
 		kubeconfigPath:       filepath.Join(opts.RunDir(), "kubetest2-kubeconfig"),
-		logsDir:              filepath.Join(opts.RunDir(), "cluster-logs"),
+		logsDir:              filepath.Join(artifacts.BaseDir(), "cluster-logs"),
 		boskosHeartbeatClose: make(chan struct{}),
 		// names need to start with an alphabet
 		instancePrefix:                 "kt2-" + pseudoUniqueSubstring(opts.RunID()),

--- a/kubetest2-gke/deployer/deployer.go
+++ b/kubetest2-gke/deployer/deployer.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/boskos/client"
 
 	"sigs.k8s.io/kubetest2/kubetest2-gke/deployer/options"
+	"sigs.k8s.io/kubetest2/pkg/artifacts"
 	"sigs.k8s.io/kubetest2/pkg/build"
 	"sigs.k8s.io/kubetest2/pkg/types"
 )
@@ -202,7 +203,7 @@ func NewDeployer(opts types.Options) *Deployer {
 
 			RetryableErrorPatterns: []string{gceStockoutErrorPattern},
 		},
-		localLogsDir: filepath.Join(opts.RunDir(), "logs"),
+		localLogsDir: filepath.Join(artifacts.BaseDir(), "logs"),
 	}
 
 	return d

--- a/kubetest2-kind/deployer/deployer.go
+++ b/kubetest2-kind/deployer/deployer.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
 
+	"sigs.k8s.io/kubetest2/pkg/artifacts"
 	"sigs.k8s.io/kubetest2/pkg/types"
 )
 
@@ -39,7 +40,7 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 	// create a deployer object and set fields that are not flag controlled
 	d := &deployer{
 		commonOptions: opts,
-		logsDir:       filepath.Join(opts.RunDir(), "logs"),
+		logsDir:       filepath.Join(artifacts.BaseDir(), "logs"),
 	}
 	// register flags and return
 	return d, bindFlags(d)


### PR DESCRIPTION
Fallout from https://github.com/kubernetes-sigs/kubetest2/pull/183

Logs used to be uploaded because rundir was inside of ARTIFACTS, e.g. https://gcsweb.k8s.io/gcs/kubernetes-jenkins/logs/ci-kubernetes-gce-conformance-latest-kubetest2/1540532050887446528/artifacts/eb7a368d-f433-11ec-9e31-9224b4edca5e/