### PR TITLE
Don't shut down on control-C, if we should not shut down

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -97,9 +97,11 @@ func RealMain(opts types.Options, d types.Deployer, tester types.Tester) (result
 			select {
 			case <-c:
 				if opts.ShouldUp() || opts.ShouldTest() {
-					klog.Info("Captured ^C, gracefully attempting to cleanup resources..")
-					if err := writer.WrapStep("Down", d.Down); err != nil {
-						result = err
+					if opts.ShouldDown() {
+						klog.Info("Captured ^C, gracefully attempting to cleanup resources..")
+						if err := writer.WrapStep("Down", d.Down); err != nil {
+							result = err
+						}
 					}
 					os.Exit(0)
 				}


### PR DESCRIPTION
If the user has asked us not to shut down the cluster, don't shut it
down if they control-C out of long running tests.

Allows for iterative test debugging etc.
