### PR TITLE
allow to specify the ingress-gce image to use in the cluster

### DIFF
--- a/kubetest2-gce/deployer/common.go
+++ b/kubetest2-gce/deployer/common.go
@@ -197,6 +197,10 @@ func (d *deployer) buildEnv() []string {
 		env = append(env, fmt.Sprintf("KUBE_GCE_NODE_SERVICE_ACCOUNT=%s", d.NodeServiceAccount))
 	}
 
+	if d.IngressGCEImage != "" {
+		env = append(env, fmt.Sprintf("GCE_GLBC_IMAGE=%s", d.IngressGCEImage))
+	}
+
 	return env
 }
 

--- a/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2-gce/deployer/deployer.go
@@ -88,6 +88,8 @@ type deployer struct {
 
 	MasterSize string `desc:"Sets the MASTER_SIZE environment variable during deployment."`
 	NodeSize   string `desc:"Sets the NODE_SIZE environment variable during deployment."`
+
+	IngressGCEImage string `desc:"Sets the ingress-gce image used for the Ingress and Loadbalancer controller."`
 }
 
 // pseudoUniqueSubstring returns a substring of a UUID


### PR DESCRIPTION
Needed to run presubmits on ingress-gce https://github.com/kubernetes/ingress-gce/pull/1978