### PR TITLE
fix: remove reference to kubernetes-release bucket

### DIFF
--- a/pkg/testers/ginkgo/ginkgo.go
+++ b/pkg/testers/ginkgo/ginkgo.go
@@ -42,7 +42,7 @@ type Tester struct {
 	Parallel           int    `desc:"Run this many tests in parallel at once."`
 	SkipRegex          string `desc:"Regular expression of jobs to skip."`
 	FocusRegex         string `desc:"Regular expression of jobs to focus on."`
-	TestPackageVersion string `desc:"The ginkgo tester uses a test package made during the kubernetes build. The tester downloads this test package from one of the release tars published to GCS. Defaults to latest. Use \"gsutil ls gs://kubernetes-release/release/\" to find release names. Example: v1.20.0-alpha.0"`
+	TestPackageVersion string `desc:"The ginkgo tester uses a test package made during the kubernetes build. The tester downloads this test package from one of the release tars published to the Release bucket. Defaults to latest. visit https://kubernetes.io/releases/ to find release names. Example: v1.20.0-alpha.0"`
 	TestPackageBucket  string `desc:"The bucket which release tars will be downloaded from to acquire the test package. Defaults to the main kubernetes project bucket."`
 	TestPackageDir     string `desc:"The directory in the bucket which represents the type of release. Default to the release directory."`
 	TestPackageMarker  string `desc:"The version marker in the directory containing the package version to download when unspecified. Defaults to latest.txt."`


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
There are still references to gs://kubernetes-release which is being replaced with a fully community-owned bucket. However the new bucket does not support listing and finding files in a similar fashion to `gsutil ls`. This change points users towards the kubernetes release page to locate appropriate versions. 

ref: https://github.com/kubernetes/k8s.io/issues/2396
