### PR TITLE
Fix flag redefined panic error

### DIFF
--- a/kubetest2-noop/deployer/deployer.go
+++ b/kubetest2-noop/deployer/deployer.go
@@ -102,7 +102,6 @@ func bindFlags(d *deployer) *pflag.FlagSet {
 		return nil
 	}
 
-	klog.InitFlags(nil)
 	flags.AddGoFlagSet(flag.CommandLine)
 
 	return flags

--- a/pkg/testers/clusterloader2/cl2.go
+++ b/pkg/testers/clusterloader2/cl2.go
@@ -110,7 +110,6 @@ func (t *Tester) Execute() error {
 		return fmt.Errorf("failed to initialize tester: %v", err)
 	}
 
-	klog.InitFlags(nil)
 	fs.AddGoFlagSet(flag.CommandLine)
 
 	help := fs.BoolP("help", "h", false, "")

--- a/pkg/testers/ginkgo/ginkgo.go
+++ b/pkg/testers/ginkgo/ginkgo.go
@@ -201,7 +201,6 @@ func (t *Tester) Execute() error {
 		return fmt.Errorf("failed to initialize tester: %v", err)
 	}
 
-	klog.InitFlags(nil)
 	fs.AddGoFlagSet(flag.CommandLine)
 
 	help := fs.BoolP("help", "h", false, "")

--- a/pkg/testers/node/node.go
+++ b/pkg/testers/node/node.go
@@ -103,7 +103,6 @@ func (t *Tester) Execute() error {
 		return fmt.Errorf("failed to initialize tester: %v", err)
 	}
 
-	klog.InitFlags(nil)
 	fs.AddGoFlagSet(flag.CommandLine)
 
 	help := fs.BoolP("help", "h", false, "")


### PR DESCRIPTION
Merge of change https://github.com/kubernetes-sigs/kubetest2/pull/234 has introduced panic errors of below kind:
```
Error: /home/prow/go/bin/kubetest2-tester-ginkgo flag redefined: alsologtostderr
panic: /home/prow/go/bin/kubetest2-tester-ginkgo flag redefined: alsologtostderr
goroutine 1 [running]:
flag.(*FlagSet).Var(0xc000130120, {0x1e2da28, 0x2e0f129}, {0x1b0e848, 0xf}, {0x1b8ea78, 0x49})
	flag/flag.go:982 +0x2dc
k8s.io/klog/v2.InitFlags.func1(0xc000120480?)
	k8s.io/klog/v2@v2.100.1/klog.go:437 +0x4c
flag.(*FlagSet).VisitAll(0x55?, 0xc000c3fe10)
	flag/flag.go:447 +0x68
k8s.io/klog/v2.InitFlags(0x19ec5e0?)
	k8s.io/klog/v2@v2.100.1/klog.go:436 +0x60
sigs.k8s.io/kubetest2/pkg/testers/ginkgo.(*Tester).Execute(0x60?)
	sigs.k8s.io/kubetest2/pkg/testers/ginkgo/ginkgo.go:204 +0xa4
sigs.k8s.io/kubetest2/pkg/testers/ginkgo.Main()
	sigs.k8s.io/kubetest2/pkg/testers/ginkgo/ginkgo.go:256 +0x7c
main.main()
	sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo/main.go:24 +0x24 
```
The commit https://github.com/kubernetes-sigs/kubetest2/pull/234/commits/85dfb4e8e7f8503e3ea777e02f594e1e1807a753 seemed to have missed removing `klog.InitFlags(nil)` from tester files and noop deployer file.