### PR TITLE
Support for --cloud-provider and --featuregates

### DIFF
--- a/kubetest2-gce/deployer/common.go
+++ b/kubetest2-gce/deployer/common.go
@@ -201,6 +201,14 @@ func (d *deployer) buildEnv() []string {
 		env = append(env, fmt.Sprintf("GCE_GLBC_IMAGE=%s", d.IngressGCEImage))
 	}
 
+	if d.CloudProvider != "" {
+		env = append(env, fmt.Sprintf("CLOUD_PROVIDER=%s", d.CloudProvider))
+	}
+
+	if d.FeatureGates != "" {
+		env = append(env, fmt.Sprintf("KUBE_FEATURE_GATES=%s", d.FeatureGates))
+	}
+
 	return env
 }
 

--- a/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2-gce/deployer/deployer.go
@@ -85,6 +85,8 @@ type deployer struct {
 	CreateCustomNetwork         bool   `desc:"Sets the environment variable CREATE_CUSTOM_NETWORK=true during deployment."`
 	NodeScopes                  string `desc:"Sets the NODE_SCOPES environment variable during deployment."`
 	NodeServiceAccount          string `desc:"Sets the KUBE_GCE_NODE_SERVICE_ACCOUNT environment variable during deployment."`
+	CloudProvider               string `desc:"Sets the CLOUD_PROVIDER environment variable during deployment."`
+	FeatureGates                string `desc:"Sets the KUBE_FEATURE_GATES environment variable during deployment."`
 
 	MasterSize string `desc:"Sets the MASTER_SIZE environment variable during deployment."`
 	NodeSize   string `desc:"Sets the NODE_SIZE environment variable during deployment."`


### PR DESCRIPTION
Needed for https://github.com/kubernetes/kubernetes/issues/120367

we have to set both the cloud-provider (to `gce`) and the disable feature gates (for in-tree cloud provider and in-tree kubelet cred provider)