### PR TITLE
Fix env var key - should be CLOUD_PROVIDER_FLAG

### DIFF
--- a/kubetest2-gce/deployer/common.go
+++ b/kubetest2-gce/deployer/common.go
@@ -202,7 +202,7 @@ func (d *deployer) buildEnv() []string {
 	}
 
 	if d.CloudProvider != "" {
-		env = append(env, fmt.Sprintf("CLOUD_PROVIDER=%s", d.CloudProvider))
+		env = append(env, fmt.Sprintf("CLOUD_PROVIDER_FLAG=%s", d.CloudProvider))
 	}
 
 	if d.FeatureGates != "" {


### PR DESCRIPTION
xref: https://github.com/kubernetes/kubernetes/issues/120367

Almost there w.r.t kubetest2 job. the feature-gates are being passed through, but i got the env var key for the cloud provider wrong.

(see https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-gce-conformance-latest-kubetest2/1698135421877227520/artifacts/cluster-logs/kt2-bd437511-67a4-master/kube-apiserver.log)