### PR TITLE
Prune junit xml file when things get too big

### DIFF
--- a/pkg/testers/ginkgo/ginkgo.go
+++ b/pkg/testers/ginkgo/ginkgo.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/kubetest2/pkg/build"
 	"sigs.k8s.io/kubetest2/pkg/exec"
 	"sigs.k8s.io/kubetest2/pkg/testers"
+	"sigs.k8s.io/kubetest2/pkg/testers/ginkgo/junitxml"
 )
 
 var GitTag string
@@ -105,6 +106,8 @@ func (t *Tester) Test() error {
 		t.e2eTestPath,
 		"--")
 	ginkgoArgs = append(ginkgoArgs, e2eTestArgs...)
+
+	defer junitxml.Clean()
 
 	klog.V(0).Infof("Running ginkgo test as %s %+v", t.ginkgoPath, ginkgoArgs)
 	cmd := exec.Command(t.ginkgoPath, ginkgoArgs...)

--- a/pkg/testers/ginkgo/junitxml/prune.go
+++ b/pkg/testers/ginkgo/junitxml/prune.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package junitxml
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"sigs.k8s.io/kubetest2/pkg/artifacts"
+)
+
+const maxTextSize = 1 // one MB
+
+func Clean() {
+	xmlFile := filepath.Join(artifacts.BaseDir(), "junit_01.xml")
+	_, err := os.Stat(xmlFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			fmt.Printf("junit xml file %s not present.\n", xmlFile)
+		} else {
+			fmt.Printf("error opening junit xml file %s : %s\n", xmlFile, err)
+		}
+		return
+	}
+	fmt.Printf("processing junit xml file : %s\n", xmlFile)
+	xmlReader, err := os.Open(xmlFile)
+	if err != nil {
+		return
+	}
+	defer xmlReader.Close()
+	suites, err := fetchXML(xmlReader) // convert MB into bytes (roughly!)
+	if err != nil {
+		fmt.Printf("error fetching xml : %s\n", err)
+		return
+	}
+
+	pruneXML(suites, maxTextSize*1e6) // convert MB into bytes (roughly!)
+
+	xmlWriter, err := os.OpenFile(xmlFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+	if err != nil {
+		fmt.Printf("error opening file to write xml : %s\n", err)
+		return
+	}
+	defer xmlWriter.Close()
+	err = streamXML(xmlWriter, suites)
+	if err != nil {
+		fmt.Printf("error streaming xml to file: %s\n", err)
+		return
+	}
+	fmt.Println("done.")
+}
+
+func pruneXML(suites *JUnitTestSuites, maxBytes int) {
+	for _, suite := range suites.Suites {
+		for _, testcase := range suite.TestCases {
+			if testcase.SkipMessage != nil {
+				if len(testcase.SkipMessage.Message) > maxBytes {
+					fmt.Printf("clipping skip message in test case : %s\n", testcase.Name)
+					head := testcase.SkipMessage.Message[:maxBytes/2]
+					tail := testcase.SkipMessage.Message[len(testcase.SkipMessage.Message)-maxBytes/2:]
+					testcase.SkipMessage.Message = head + "[...clipped...]" + tail
+				}
+			}
+			if testcase.Failure != nil {
+				if len(testcase.Failure.Contents) > maxBytes {
+					fmt.Printf("clipping failure message in test case : %s\n", testcase.Name)
+					head := testcase.Failure.Contents[:maxBytes/2]
+					tail := testcase.Failure.Contents[len(testcase.Failure.Contents)-maxBytes/2:]
+					testcase.Failure.Contents = head + "[...clipped...]" + tail
+				}
+			}
+		}
+	}
+}
+
+func fetchXML(xmlReader io.Reader) (*JUnitTestSuites, error) {
+	decoder := xml.NewDecoder(xmlReader)
+	var suites JUnitTestSuites
+	err := decoder.Decode(&suites)
+	if err != nil {
+		return nil, err
+	}
+	return &suites, nil
+}
+
+func streamXML(writer io.Writer, in *JUnitTestSuites) error {
+	_, err := writer.Write([]byte("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"))
+	if err != nil {
+		return err
+	}
+	encoder := xml.NewEncoder(writer)
+	encoder.Indent("", "\t")
+	err = encoder.Encode(in)
+	if err != nil {
+		return err
+	}
+	return encoder.Flush()
+}

--- a/pkg/testers/ginkgo/junitxml/report.go
+++ b/pkg/testers/ginkgo/junitxml/report.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*Package junitxml creates a JUnit XML report from a testjson.Execution.
+ */
+package junitxml
+
+import (
+	"encoding/xml"
+)
+
+// JUnitTestSuites is a collection of JUnit test suites.
+type JUnitTestSuites struct {
+	XMLName xml.Name         `xml:"testsuites"`
+	Suites  []JUnitTestSuite `xml:"testsuite,omitempty"`
+}
+
+// JUnitTestSuite is a single JUnit test suite which may contain many
+// testcases.
+type JUnitTestSuite struct {
+	XMLName    xml.Name        `xml:"testsuite"`
+	Tests      int             `xml:"tests,attr"`
+	Failures   int             `xml:"failures,attr"`
+	Time       string          `xml:"time,attr"`
+	Name       string          `xml:"name,attr"`
+	Properties []JUnitProperty `xml:"properties>property,omitempty"`
+	TestCases  []JUnitTestCase `xml:"testcase,omitempty"`
+	Timestamp  string          `xml:"timestamp,attr"`
+}
+
+// JUnitTestCase is a single test case with its result.
+type JUnitTestCase struct {
+	XMLName     xml.Name          `xml:"testcase"`
+	Classname   string            `xml:"classname,attr"`
+	Name        string            `xml:"name,attr"`
+	Time        string            `xml:"time,attr"`
+	SkipMessage *JUnitSkipMessage `xml:"skipped,omitempty"`
+	Failure     *JUnitFailure     `xml:"failure,omitempty"`
+}
+
+// JUnitSkipMessage contains the reason why a testcase was skipped.
+type JUnitSkipMessage struct {
+	Message string `xml:"message,attr"`
+}
+
+// JUnitProperty represents a key/value pair used to define properties.
+type JUnitProperty struct {
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+}
+
+// JUnitFailure contains data related to a failed test.
+type JUnitFailure struct {
+	Message  string `xml:"message,attr"`
+	Type     string `xml:"type,attr"`
+	Contents string `xml:",chardata"`
+}


### PR DESCRIPTION
Copied over from:
https://github.com/kubernetes/kubernetes/tree/master/cmd/prune-junit-xml

Context:
- https://github.com/kubernetes/kubernetes/pull/109112
- https://github.com/GoogleCloudPlatform/testgrid/pull/877