### PR TITLE
Fix legacy updown cluster tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ See individual READMEs for more information
 - [`kubetest2-aks`][kubetest2-aks]
 - [`kubetest2-kops`][kubetest2-kops]
 - [`kubetest2-tf`][kubetest2-tf]
+- [`kubetest2-ec2`][kubetest2-ec2]
 
 **Testers**
 - [`kubetest2-tester-kops`][kubetest2-tester-kops]
@@ -111,6 +112,6 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 [kubetest2-aks]: https://sigs.k8s.io/cloud-provider-azure/kubetest2-aks
 [kubetest2-kops]: https://git.k8s.io/kops/tests/e2e/kubetest2-kops
 [kubetest2-tf]: https://github.com/ppc64le-cloud/kubetest2-plugins/tree/master/kubetest2-tf
+[kubetest2-ec2]: https://github.com/kubernetes-sigs/provider-aws-test-infra/tree/main/kubetest2-ec2
 [kubetest2-tester-kops]: https://git.k8s.io/kops/tests/e2e/kubetest2-tester-kops
-
 [k8s-supported-releases]: https://kubernetes.io/releases/patch-releases/#support-period

--- a/kubetest2-gce/ci-tests/buildupdown-legacy.sh
+++ b/kubetest2-gce/ci-tests/buildupdown-legacy.sh
@@ -36,10 +36,11 @@ kubetest2 gce \
     --target-build-arch=linux/amd64 \
     --master-size=e2-standard-2 \
     --node-size=e2-standard-2 \
-    --env=KUBE_IMAGE_FAMILY=ubuntu-2204-lts \
     --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu \
+    --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2204-jammy-v20230531 \
     --env=KUBE_GCE_MASTER_PROJECT=ubuntu-os-cloud \
     --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu \
+    --env=KUBE_GCE_NODE_IMAGE=ubuntu-2204-jammy-v20230531 \
     --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud \
     -- \
     --focus-regex='Secrets should be consumable via the environment' \


### PR DESCRIPTION
I wanted to amend kube-up clusters to pick the latest image in an image family instead of using a hardcoded image. 

Turns out it is a messy change: https://github.com/kubernetes/kubernetes/pull/120144

/cc @jbpratt @michelle192837 