### PR TITLE
Configure ginkgo to look for packages in rundir by default

### DIFF
--- a/kubetest2-gce/ci-tests/buildupdown-legacy.sh
+++ b/kubetest2-gce/ci-tests/buildupdown-legacy.sh
@@ -45,4 +45,5 @@ kubetest2 gce \
     -- \
     --focus-regex='Secrets should be consumable via the environment' \
     --skip-regex='\[Driver:.gcepd\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]' \
+    --use-built-binaries=true \
     --timeout=30m

--- a/pkg/testers/ginkgo/ginkgo.go
+++ b/pkg/testers/ginkgo/ginkgo.go
@@ -48,7 +48,7 @@ type Tester struct {
 	TestPackageDir     string        `desc:"The directory in the bucket which represents the type of release. Default to the release directory."`
 	TestPackageMarker  string        `desc:"The version marker in the directory containing the package version to download when unspecified. Defaults to latest.txt."`
 	TestArgs           string        `desc:"Additional arguments supported by the e2e test framework (https://godoc.org/k8s.io/kubernetes/test/e2e/framework#TestContextType)."`
-	UseBuiltBinaries   bool          `desc:"Look for binaries in $KUBETEST2_RUN_DIR instead of extracting from tars downloaded from GCS."`
+	UseBuiltBinaries   bool          `desc:"Look for binaries in _rundir/$KUBETEST2_RUN_DIR instead of extracting from tars downloaded from GCS."`
 	Timeout            time.Duration `desc:"How long (in golang duration format) to wait for ginkgo tests to complete."`
 
 	kubeconfigPath string
@@ -223,6 +223,11 @@ func (t *Tester) Execute() error {
 func (t *Tester) initKubetest2Info() error {
 	if dir, ok := os.LookupEnv("KUBETEST2_RUN_DIR"); ok {
 		t.runDir = dir
+		return nil
+	}
+	// ginkgo/e2e.test/kubectl can be found in rundir when they are built
+	if t.UseBuiltBinaries {
+		t.runDir = artifacts.RunDir()
 		return nil
 	}
 	// default to current working directory if for some reason the env is not set


### PR DESCRIPTION
If you pass --use-built-binaries, ginkgo looks for kubectl at the root of the pwd instead of _rundir/RUN_ID/kubectl

```
I1013 20:23:03.280737   84443 ginkgo.go:141] Using kubeconfig at /root/.kube/config
F1013 20:23:03.280795   84443 tester.go:469] failed to run ginkgo tester: failed to validate pre-built binary kubectl (checked at "/home/prow/go/src/k8s.io/kubernetes/kubectl"): stat kubectl: no such file or directory
```

https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kops/16018/pull-kops-kubernetes-e2e-ubuntu-gce-build/1712916991666294784/build-log.txt

Part of https://github.com/kubernetes/kops/pull/16018