### PR TITLE
export all deployer struct

### DIFF
--- a/kubetest2-gce/deployer/build.go
+++ b/kubetest2-gce/deployer/build.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/kubetest2/pkg/exec"
 )
 
-func (d *deployer) Build() error {
+func (d *Deployer) Build() error {
 	klog.V(1).Info("GCE deployer starting Build()")
 
 	if err := d.init(); err != nil {
@@ -91,7 +91,7 @@ func (d *deployer) Build() error {
 	return nil
 }
 
-func (d *deployer) setRepoPathIfNotSet() error {
+func (d *Deployer) setRepoPathIfNotSet() error {
 	if d.RepoRoot != "" {
 		return nil
 	}
@@ -107,7 +107,7 @@ func (d *deployer) setRepoPathIfNotSet() error {
 }
 
 // verifyBuildFlags only checks flags that are needed for Build
-func (d *deployer) verifyBuildFlags() error {
+func (d *Deployer) verifyBuildFlags() error {
 	if err := d.setRepoPathIfNotSet(); err != nil {
 		return err
 	}

--- a/kubetest2-gce/deployer/build_test.go
+++ b/kubetest2-gce/deployer/build_test.go
@@ -30,7 +30,7 @@ func TestSetRepoPathIfNotSet(t *testing.T) {
 	cases := []struct {
 		name string
 
-		initialDeployer  deployer
+		initialDeployer  Deployer
 		expectedRepoPath string
 	}{
 		{
@@ -39,7 +39,7 @@ func TestSetRepoPathIfNotSet(t *testing.T) {
 		},
 		{
 			name: "set preset repo path",
-			initialDeployer: deployer{
+			initialDeployer: Deployer{
 				RepoRoot: "/test/path",
 			},
 			expectedRepoPath: "/test/path",

--- a/kubetest2-gce/deployer/common.go
+++ b/kubetest2-gce/deployer/common.go
@@ -33,14 +33,14 @@ const (
 	gceProjectResourceType = "gce-project"
 )
 
-func (d *deployer) init() error {
+func (d *Deployer) init() error {
 	var err error
 	d.doInit.Do(func() { err = d.initialize() })
 	return err
 }
 
 // initialize should only be called by init(), behind a sync.Once
-func (d *deployer) initialize() error {
+func (d *Deployer) initialize() error {
 	if d.commonOptions.ShouldBuild() {
 		if err := d.verifyBuildFlags(); err != nil {
 			return fmt.Errorf("init failed to check build flags: %s", err)
@@ -87,7 +87,7 @@ func (d *deployer) initialize() error {
 	return nil
 }
 
-func (d *deployer) buildEnv() []string {
+func (d *Deployer) buildEnv() []string {
 	// The base env currently does not inherit the current os env (except for PATH)
 	// because (for now) it doesn't have to. In future, this may have to change when
 	// support is added for k/k's kube-up.sh and kube-down.sh which support a wide
@@ -246,7 +246,7 @@ func getClusterIPRange(numNodes int) string {
 // returns the path to the binary, error if it doesn't exist
 // kubectl detection using legacy verify-get-kube-binaries is unreliable
 // https://github.com/kubernetes/kubernetes/blob/b10d82b93bad7a4e39b9d3f5c5e81defa3af68f0/cluster/kubectl.sh#L25-L26
-func (d *deployer) verifyKubectl() (string, error) {
+func (d *Deployer) verifyKubectl() (string, error) {
 	klog.V(2).Infof("checking locally built kubectl ...")
 	localKubectl := filepath.Join(d.commonOptions.RunDir(), "kubectl")
 	if _, err := os.Stat(localKubectl); err == nil {

--- a/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2-gce/deployer/deployer.go
@@ -42,7 +42,7 @@ const Name = "gce"
 
 var GitTag string
 
-type deployer struct {
+type Deployer struct {
 	// generic parts
 	commonOptions types.Options
 
@@ -120,7 +120,7 @@ func pseudoUniqueSubstring(uuid string) string {
 
 // New implements deployer.New for gce
 func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
-	d := &deployer{
+	d := &Deployer{
 		commonOptions: opts,
 		BuildOptions: &options.BuildOptions{
 			CommonBuildOptions: &build.Options{
@@ -144,7 +144,7 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 
 	flagSet, err := gpflag.Parse(d)
 	if err != nil {
-		klog.Fatalf("couldn't parse flagset for deployer struct: %s", err)
+		klog.Fatalf("couldn't parse flagset for Deployer struct: %s", err)
 	}
 
 	flagSet.AddGoFlagSet(goflag.CommandLine)
@@ -157,17 +157,17 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 var _ types.NewDeployer = New
 
 // assert that deployer implements types.Deployer
-var _ types.Deployer = &deployer{}
+var _ types.Deployer = &Deployer{}
 
-func (d *deployer) Provider() string {
+func (d *Deployer) Provider() string {
 	return Name
 }
 
-func (d *deployer) Version() string {
+func (d *Deployer) Version() string {
 	return GitTag
 }
 
-func (d *deployer) Kubeconfig() (string, error) {
+func (d *Deployer) Kubeconfig() (string, error) {
 	_, err := os.Stat(d.kubeconfigPath)
 	if os.IsNotExist(err) {
 		return "", fmt.Errorf("kubeconfig does not exist at: %s", d.kubeconfigPath)

--- a/kubetest2-gce/deployer/down.go
+++ b/kubetest2-gce/deployer/down.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/kubetest2/pkg/exec"
 )
 
-func (d *deployer) Down() error {
+func (d *Deployer) Down() error {
 	klog.V(1).Info("GCE deployer starting Down()")
 
 	if err := d.init(); err != nil {
@@ -70,7 +70,7 @@ func (d *deployer) Down() error {
 	return nil
 }
 
-func (d *deployer) verifyDownFlags() error {
+func (d *Deployer) verifyDownFlags() error {
 	if err := d.setRepoPathIfNotSet(); err != nil {
 		return err
 	}

--- a/kubetest2-gce/deployer/dumplogs.go
+++ b/kubetest2-gce/deployer/dumplogs.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/kubetest2/pkg/exec"
 )
 
-func (d *deployer) DumpClusterLogs() error {
+func (d *Deployer) DumpClusterLogs() error {
 	klog.V(1).Info("GCE deployer starting DumpClusterLogs()")
 
 	if err := d.init(); err != nil {
@@ -53,7 +53,7 @@ func (d *deployer) DumpClusterLogs() error {
 	return nil
 }
 
-func (d *deployer) makeLogsDir() error {
+func (d *Deployer) makeLogsDir() error {
 	_, err := os.Stat(d.logsDir)
 
 	if os.IsNotExist(err) {
@@ -86,7 +86,7 @@ func (d *deployer) makeLogsDir() error {
 	return fmt.Errorf("cluster logs directory %s already exists, please clean up manually or use the overwrite flag before continuing", d.logsDir)
 }
 
-func (d *deployer) sshDump() error {
+func (d *Deployer) sshDump() error {
 	env := d.buildEnv()
 
 	args := []string{
@@ -105,7 +105,7 @@ func (d *deployer) sshDump() error {
 	return nil
 }
 
-func (d *deployer) kubectlDump() error {
+func (d *Deployer) kubectlDump() error {
 	env := d.buildEnv()
 	outfile, err := os.Create(filepath.Join(d.logsDir, "cluster-info.log"))
 	if err != nil {

--- a/kubetest2-gce/deployer/firewall.go
+++ b/kubetest2-gce/deployer/firewall.go
@@ -26,15 +26,15 @@ import (
 // kube-up.sh builds NODE_TAG based on KUBE_GCE_INSTANCE_PREFIX which the deployer
 // sets as d.instacePrefix. This function replicates NODE_TAG string construction
 // because it is needed for firewall rules
-func (d *deployer) nodeTag() string {
+func (d *Deployer) nodeTag() string {
 	return fmt.Sprintf("%s-minion", d.instancePrefix)
 }
 
-func (d *deployer) nodePortRuleName() string {
+func (d *Deployer) nodePortRuleName() string {
 	return fmt.Sprintf("%s-nodeports", d.nodeTag())
 }
 
-func (d *deployer) createFirewallRuleNodePort() error {
+func (d *Deployer) createFirewallRuleNodePort() error {
 	cmd := exec.Command(
 		"gcloud", "compute", "firewall-rules", "create",
 		"--project", d.GCPProject,
@@ -51,7 +51,7 @@ func (d *deployer) createFirewallRuleNodePort() error {
 	return nil
 }
 
-func (d *deployer) deleteFirewallRuleNodePort() {
+func (d *Deployer) deleteFirewallRuleNodePort() {
 	cmd := exec.Command(
 		"gcloud", "compute", "firewall-rules", "delete",
 		"--project", d.GCPProject,

--- a/kubetest2-gce/deployer/up.go
+++ b/kubetest2-gce/deployer/up.go
@@ -32,7 +32,7 @@ const (
 	ciPublicKeyEnv  = "GCE_SSH_PUBLIC_KEY_FILE"
 )
 
-func (d *deployer) IsUp() (up bool, err error) {
+func (d *Deployer) IsUp() (up bool, err error) {
 	klog.V(1).Info("GCE deployer starting IsUp()")
 
 	if err := d.init(); err != nil {
@@ -63,7 +63,7 @@ func (d *deployer) IsUp() (up bool, err error) {
 	return len(lines) > 0, nil
 }
 
-func (d *deployer) Up() error {
+func (d *Deployer) Up() error {
 	klog.V(1).Info("GCE deployer starting Up()")
 
 	if err := d.init(); err != nil {
@@ -143,7 +143,7 @@ func enableComputeAPI(project string) error {
 	return nil
 }
 
-func (d *deployer) verifyUpFlags() error {
+func (d *Deployer) verifyUpFlags() error {
 	if d.NumNodes < 1 {
 		return fmt.Errorf("number of nodes must be at least 1")
 	}

--- a/kubetest2-kind/deployer/build.go
+++ b/kubetest2-kind/deployer/build.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/kubetest2/pkg/process"
 )
 
-func (d *deployer) Build() error {
+func (d *Deployer) Build() error {
 	args := []string{
 		"build", "node-image",
 	}

--- a/kubetest2-kind/deployer/deployer.go
+++ b/kubetest2-kind/deployer/deployer.go
@@ -38,7 +38,7 @@ var GitTag string
 // New implements deployer.New for kind
 func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 	// create a deployer object and set fields that are not flag controlled
-	d := &deployer{
+	d := &Deployer{
 		commonOptions: opts,
 		logsDir:       filepath.Join(artifacts.BaseDir(), "logs"),
 	}
@@ -49,7 +49,7 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 // assert that New implements types.NewDeployer
 var _ types.NewDeployer = New
 
-type deployer struct {
+type Deployer struct {
 	// generic parts
 	commonOptions types.Options
 	// kind specific details
@@ -63,7 +63,7 @@ type deployer struct {
 	logsDir string
 }
 
-func (d *deployer) Kubeconfig() (string, error) {
+func (d *Deployer) Kubeconfig() (string, error) {
 	if d.KubeconfigPath != "" {
 		return d.KubeconfigPath, nil
 	}
@@ -74,12 +74,12 @@ func (d *deployer) Kubeconfig() (string, error) {
 	return filepath.Join(home, ".kube", "config"), nil
 }
 
-func (d *deployer) Version() string {
+func (d *Deployer) Version() string {
 	return GitTag
 }
 
 // helper used to create & bind a flagset to the deployer
-func bindFlags(d *deployer) *pflag.FlagSet {
+func bindFlags(d *Deployer) *pflag.FlagSet {
 	flags, err := gpflag.Parse(d)
 	if err != nil {
 		klog.Fatalf("unable to generate flags from deployer")
@@ -92,7 +92,7 @@ func bindFlags(d *deployer) *pflag.FlagSet {
 }
 
 // assert that deployer implements types.DeployerWithKubeconfig
-var _ types.DeployerWithKubeconfig = &deployer{}
+var _ types.DeployerWithKubeconfig = &Deployer{}
 
 // well-known kind related constants
 const kindDefaultBuiltImageName = "kindest/node:latest"

--- a/kubetest2-kind/deployer/down.go
+++ b/kubetest2-kind/deployer/down.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/kubetest2/pkg/process"
 )
 
-func (d *deployer) Down() error {
+func (d *Deployer) Down() error {
 	args := []string{
 		"delete", "cluster",
 		"--name", d.ClusterName,

--- a/kubetest2-kind/deployer/dumplogs.go
+++ b/kubetest2-kind/deployer/dumplogs.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/kubetest2/pkg/process"
 )
 
-func (d *deployer) DumpClusterLogs() error {
+func (d *Deployer) DumpClusterLogs() error {
 	args := []string{
 		"export", "logs",
 		"--name", d.ClusterName,

--- a/kubetest2-kind/deployer/up.go
+++ b/kubetest2-kind/deployer/up.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/kubetest2/pkg/process"
 )
 
-func (d *deployer) IsUp() (up bool, err error) {
+func (d *Deployer) IsUp() (up bool, err error) {
 	// naively assume that if the api server reports nodes, the cluster is up
 	lines, err := exec.CombinedOutputLines(
 		exec.Command("kubectl", "get", "nodes", "-o=name"),
@@ -38,7 +38,7 @@ func (d *deployer) IsUp() (up bool, err error) {
 	return len(lines) > 0, nil
 }
 
-func (d *deployer) Up() error {
+func (d *Deployer) Up() error {
 	args := []string{
 		"create", "cluster",
 		"--name", d.ClusterName,

--- a/kubetest2-noop/deployer/deployer.go
+++ b/kubetest2-noop/deployer/deployer.go
@@ -37,7 +37,7 @@ var GitTag string
 // New implements deployer.New for kind
 func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 	// create a deployer object and set fields that are not flag controlled
-	d := &deployer{
+	d := &Deployer{
 		commonOptions: opts,
 	}
 	// register flags and return
@@ -47,35 +47,35 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 // assert that New implements types.NewDeployer
 var _ types.NewDeployer = New
 
-type deployer struct {
+type Deployer struct {
 	// generic parts
 	commonOptions types.Options
 
 	KubeconfigPath string `flag:"kubeconfig" desc:"Absolute path to existing kubeconfig for cluster"`
 }
 
-func (d *deployer) Up() error {
+func (d *Deployer) Up() error {
 	return nil
 }
 
-func (d *deployer) Down() error {
+func (d *Deployer) Down() error {
 	return nil
 }
 
-func (d *deployer) IsUp() (up bool, err error) {
+func (d *Deployer) IsUp() (up bool, err error) {
 	return false, nil
 }
 
-func (d *deployer) DumpClusterLogs() error {
+func (d *Deployer) DumpClusterLogs() error {
 	return nil
 }
 
-func (d *deployer) Build() error {
+func (d *Deployer) Build() error {
 	// TODO: build should probably still exist with common options
 	return nil
 }
 
-func (d *deployer) Kubeconfig() (string, error) {
+func (d *Deployer) Kubeconfig() (string, error) {
 	// noop deployer is specifically used with an existing cluster and KUBECONFIG
 	if d.KubeconfigPath != "" {
 		return d.KubeconfigPath, nil
@@ -90,12 +90,12 @@ func (d *deployer) Kubeconfig() (string, error) {
 	return filepath.Join(home, ".kube", "config"), nil
 }
 
-func (d *deployer) Version() string {
+func (d *Deployer) Version() string {
 	return GitTag
 }
 
 // helper used to create & bind a flagset to the deployer
-func bindFlags(d *deployer) *pflag.FlagSet {
+func bindFlags(d *Deployer) *pflag.FlagSet {
 	flags, err := gpflag.Parse(d)
 	if err != nil {
 		klog.Fatalf("unable to generate flags from deployer")
@@ -108,4 +108,4 @@ func bindFlags(d *deployer) *pflag.FlagSet {
 }
 
 // assert that deployer implements types.DeployerWithKubeconfig
-var _ types.DeployerWithKubeconfig = &deployer{}
+var _ types.DeployerWithKubeconfig = &Deployer{}


### PR DESCRIPTION
this will ensure that each deployer can be easily called as a library, which GKE deployer already allows (kubernetes-sigs/kubetest2#135)