### PR TITLE
Add DeployerWithInit interface

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -129,6 +129,14 @@ func RealMain(opts types.Options, d types.Deployer, tester types.Tester) (result
 
 	klog.Infof("ID for this run: %q", opts.RunID())
 
+	// If the deployer has an initialization routine, run it
+	if dWithInit, ok := d.(types.DeployerWithInit); ok {
+		if err := dWithInit.Init(); err != nil {
+			// we do not continue to up / test etc. if initialization fails
+			return err
+		}
+	}
+
 	// build if specified
 	if opts.ShouldBuild() {
 		if err := writer.WrapStep("Build", d.Build); err != nil {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -123,6 +123,14 @@ type DeployerWithVersion interface {
 	Version() string
 }
 
+// DeployerWithInit adds the ability to define initialization behavior
+type DeployerWithInit interface {
+	Deployer
+
+	// Init initializes the deployer. This will be called prior to any other lifecycle action.
+	Init() error
+}
+
 // Tester defines the "interface" between kubetest2 and a tester
 // The tester is executed as a separate binary during the Test() phase
 type Tester struct {


### PR DESCRIPTION
Adds a new interface that deployers can implement, `DeployerWithInit`, which allows a deployer to define initialization behavior. The deployer's `Init` function will be called prior to build/up/down/etc.

The initialization of a deployer may depend on its options, so cannot be done in `NewDeployer` (called when constructing the CLI).