### PR TITLE
Add DeployerWithFinish interface

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -125,6 +125,12 @@ func RealMain(opts types.Options, d types.Deployer, tester types.Tester) (result
 		if err := junitRunner.Close(); err != nil && result == nil {
 			result = err
 		}
+		// If the deployer has an Finish func, run it
+		if dWithFinish, ok := d.(types.DeployerWithFinish); ok {
+			if err := dWithFinish.Finish(); err != nil {
+				result = err
+			}
+		}
 	}()
 
 	klog.Infof("ID for this run: %q", opts.RunID())

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -131,6 +131,14 @@ type DeployerWithInit interface {
 	Init() error
 }
 
+// DeployerWithFinish adds the ability to define finalizer behavior
+type DeployerWithFinish interface {
+	Deployer
+
+	// Finish finalizes the deployer. This will be called after any other deployer action and immediately before exit.
+	Finish() error
+}
+
 // Tester defines the "interface" between kubetest2 and a tester
 // The tester is executed as a separate binary during the Test() phase
 type Tester struct {


### PR DESCRIPTION
Similar to #253, adding the ability to define a finalizer function that is called regardless of whether `--down` is used. This can be used to e.g. emit metrics, a lifecycle event, etc.