### PR TITLE
Instead of overriding the env variables add them to the environment.

### DIFF
--- a/pkg/testers/ginkgo/ginkgo.go
+++ b/pkg/testers/ginkgo/ginkgo.go
@@ -99,7 +99,9 @@ func (t *Tester) Test() error {
 
 	klog.V(0).Infof("Running ginkgo test as %s %+v", t.ginkgoPath, ginkgoArgs)
 	cmd := exec.Command(t.ginkgoPath, ginkgoArgs...)
-	cmd.SetEnv(t.Env...)
+	env := os.Environ()
+	env = append(env, t.Env...)
+	cmd.SetEnv(env...)
 	exec.InheritOutput(cmd)
 	return cmd.Run()
 }


### PR DESCRIPTION
Before this change if needed to pass additional env variable to the ginkgo tester it would remove other variables. With this change it adds variables specified in the commandline.