### PR TITLE
Support "--base-image" in kind deployer's build phase.

### DIFF
--- a/kubetest2-kind/deployer/build.go
+++ b/kubetest2-kind/deployer/build.go
@@ -35,6 +35,9 @@ func (d *deployer) Build() error {
 	if d.KubeRoot != "" {
 		args = append(args, "--kube-root", d.KubeRoot)
 	}
+	if d.BaseImage != "" {
+		args = append(args, "--base-image", d.BaseImage)
+	}
 	// set the explicitly specified image name if set
 	if d.NodeImage != "" {
 		args = append(args, "--image", d.NodeImage)

--- a/kubetest2-kind/deployer/deployer.go
+++ b/kubetest2-kind/deployer/deployer.go
@@ -54,6 +54,7 @@ type deployer struct {
 	commonOptions types.Options
 	// kind specific details
 	NodeImage      string `flag:"image-name" desc:"the image name to use for build and up"`
+	BaseImage      string `flag:"base-image" desc:"the base image name to use for the build"`
 	ClusterName    string `flag:"cluster-name" desc:"the kind cluster --name"`
 	BuildType      string `desc:"--type for kind build node-image"`
 	ConfigPath     string `flag:"config" desc:"--config for kind create cluster"`


### PR DESCRIPTION
In kind, container runtimes(high level and low level) are installed in [Base Image](https://kind.sigs.k8s.io/docs/design/base-image/).

Sometimes, E2E which requires custom-built container runtimes(contained, CRI-O, crun, etc.) needs to use custom base image when building kind node image.

But, because current `kubetest2-kind` does not support specifying the base image in `build` phase, kubetest2 users need to build the node image separately and then run kind deployer like this:

```shell
$ kind build node-image --base-image=... --image=...
$ kubetest2 kind --up --image=... --test=...
```

Thus, this PR just adds `--base-image` in kind deployer to make it in just one line:

```shell
$ kubetest2 kind --build --up --base-image=... --test=...
```