### PR TITLE
Remove deprecated --kube-root kind argument

### DIFF
--- a/kubetest2-kind/deployer/build.go
+++ b/kubetest2-kind/deployer/build.go
@@ -29,11 +29,11 @@ func (d *deployer) Build() error {
 	args := []string{
 		"build", "node-image",
 	}
+	if d.KubeRoot != "" {
+		args = append(args, d.KubeRoot)
+	}
 	if d.BuildType != "" {
 		args = append(args, "--type", d.BuildType)
-	}
-	if d.KubeRoot != "" {
-		args = append(args, "--kube-root", d.KubeRoot)
 	}
 	if d.BaseImage != "" {
 		args = append(args, "--base-image", d.BaseImage)

--- a/kubetest2-kind/deployer/deployer.go
+++ b/kubetest2-kind/deployer/deployer.go
@@ -59,7 +59,7 @@ type deployer struct {
 	BuildType      string `desc:"--type for kind build node-image"`
 	ConfigPath     string `flag:"config" desc:"--config for kind create cluster"`
 	KubeconfigPath string `flag:"kubeconfig" desc:"--kubeconfig flag for kind create cluster"`
-	KubeRoot       string `desc:"--kube-root for kind build node-image"`
+	KubeRoot       string `desc:"the Kubernetes source for kind build node-image"`
 
 	logsDir string
 }


### PR DESCRIPTION
The `--kube-root` flag for kind has been deprecated and will be removed soon. The current method for the equivalent functionality is to pass this path to the k8s source directory as the first non-flag argument to `kind build node-image`.

This removes the deprecated usage and updates the help text to reflect the new implementation.

Related: https://github.com/kubernetes-sigs/kind/issues/3717