### PR TITLE
kubetest-gce: dumpcluster logs after it run

### DIFF
--- a/kubetest2-gce/deployer/down.go
+++ b/kubetest2-gce/deployer/down.go
@@ -28,6 +28,10 @@ import (
 func (d *deployer) Down() error {
 	klog.V(1).Info("GCE deployer starting Down()")
 
+	if err := d.DumpClusterLogs(); err != nil {
+		klog.Warningf("Dumping cluster logs at the begin of Down() failed: %s", err)
+	}
+
 	if err := d.init(); err != nil {
 		return fmt.Errorf("down failed to init: %s", err)
 	}


### PR DESCRIPTION
Only dump cluster logs on Up if the cluster is not able to created, otherwise logs them before tearing down the cluster

