### PR TITLE
Dump cluster logs when necessary

### DIFF
--- a/kubetest2-gke/deployer/down.go
+++ b/kubetest2-gke/deployer/down.go
@@ -36,6 +36,10 @@ func (d *Deployer) Down() error {
 		return nil
 	}
 
+	if err := d.DumpClusterLogs(); err != nil {
+		klog.Warningf("Dumping cluster logs at the end of Up() failed: %v", err)
+	}
+
 	// If the GCP projects are acquired from Boskos, release the projects and
 	// rely on boskos-janitor to do clean-ups for them.
 	if d.totalBoskosProjectsRequested > 0 {

--- a/kubetest2-gke/deployer/up.go
+++ b/kubetest2-gke/deployer/up.go
@@ -38,24 +38,26 @@ func (d *Deployer) Up() error {
 		return err
 	}
 
-	defer func() {
-		if d.RepoRoot == "" {
-			klog.Warningf("repo-root not supplied, skip dumping cluster logs")
-			return
-		}
-		if err := d.DumpClusterLogs(); err != nil {
-			klog.Warningf("Dumping cluster logs at the end of Up() failed: %v", err)
-		}
-	}()
-
 	if err := d.CreateNetwork(); err != nil {
 		return err
 	}
 	if err := d.CreateClusters(); err != nil {
+		if d.RepoRoot == "" {
+			klog.Warningf("repo-root not supplied, skip dumping cluster logs")
+		}
+		if err := d.DumpClusterLogs(); err != nil {
+			klog.Warningf("Dumping cluster logs at the end of Up() failed: %v", err)
+		}
 		return fmt.Errorf("error creating the clusters: %w", err)
 	}
 
 	if err := d.TestSetup(); err != nil {
+		if d.RepoRoot == "" {
+			klog.Warningf("repo-root not supplied, skip dumping cluster logs")
+		}
+		if err := d.DumpClusterLogs(); err != nil {
+			klog.Warningf("Dumping cluster logs at the end of Up() failed: %v", err)
+		}
 		return fmt.Errorf("error running setup for the tests: %w", err)
 	}
 

--- a/kubetest2-kind/deployer/down.go
+++ b/kubetest2-kind/deployer/down.go
@@ -25,6 +25,9 @@ import (
 )
 
 func (d *deployer) Down() error {
+	if err := d.DumpClusterLogs(); err != nil {
+		klog.Warningf("Dumping cluster logs at the start of Down() failed: %v", err)
+	}
 	args := []string{
 		"delete", "cluster",
 		"--name", d.ClusterName,


### PR DESCRIPTION
We need the cluster logs in two situations:
- when the cluster fails to be created
- after running the tests, before we start tearing down the cluster

