### PR TITLE
build e2e requirements for kind deployer

### DIFF
--- a/kubetest2-kind/deployer/build.go
+++ b/kubetest2-kind/deployer/build.go
@@ -17,19 +17,19 @@ limitations under the License.
 package deployer
 
 import (
-	"os"
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
-
 
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/kubetest2/pkg/build"
-	"sigs.k8s.io/kubetest2/pkg/process"
 	"sigs.k8s.io/kubetest2/pkg/exec"
 	"sigs.k8s.io/kubetest2/pkg/fs"
+	"sigs.k8s.io/kubetest2/pkg/process"
 )
+
 const (
 	target = "all"
 )
@@ -64,7 +64,7 @@ func (d *deployer) Build() error {
 	e2ePath := "test/e2e/e2e.test"
 	kubectlPath := "cmd/kubectl"
 	ginkgoPath := "vendor/github.com/onsi/ginkgo/v2/ginkgo"
-	
+
 	// Ginkgo v1 is used by Kubernetes 1.24 and earlier, fallback if v2 is not available.
 	_, err := os.Stat(ginkgoPath)
 	if err != nil {
@@ -83,7 +83,7 @@ func (d *deployer) Build() error {
 	//move files
 	const dockerizedOutput = "_output/dockerized"
 	for _, binary := range build.CommonTestBinaries {
-		source := filepath.Join(d.KubeRoot,"_output/bin", binary)
+		source := filepath.Join(d.KubeRoot, "_output/bin", binary)
 		dest := filepath.Join(d.KubeRoot, dockerizedOutput, "bin", runtime.GOOS, runtime.GOARCH, binary)
 		if err := fs.CopyFile(source, dest); err != nil {
 			klog.Warningf("failed to copy %s to %s: %v", source, dest, err)

--- a/kubetest2-kind/deployer/build.go
+++ b/kubetest2-kind/deployer/build.go
@@ -65,12 +65,6 @@ func (d *deployer) Build() error {
 	kubectlPath := "cmd/kubectl"
 	ginkgoPath := "vendor/github.com/onsi/ginkgo/v2/ginkgo"
 
-	// Ginkgo v1 is used by Kubernetes 1.24 and earlier, fallback if v2 is not available.
-	_, err := os.Stat(ginkgoPath)
-	if err != nil {
-		ginkgoPath = "vendor/github.com/onsi/ginkgo/ginkgo"
-	}
-
 	// make sure we have e2e requirements
 	cmd := exec.Command("make", target,
 		fmt.Sprintf("WHAT=%s %s %s", kubectlPath, e2ePath, ginkgoPath))


### PR DESCRIPTION
This should fix https://github.com/kubernetes-sigs/kubetest2/issues/184

This changes ensures e2e requirements can be found in _rundir/$KUBETEST2_RUN_DIR
as described in https://github.com/kubernetes-sigs/kubetest2/blob/696b35899d305521225596d58cc27c33c6638994/pkg/testers/ginkgo/ginkgo.go#L50

---
I replicatrd the same behavior from https://github.com/kubernetes-sigs/kind/blob/main/hack/ci/e2e-k8s.sh#L72-L86