### PR TITLE
Add ppc64le architecture to kubetest2 available archs

### DIFF
--- a/hack/build/ci-binaries.sh
+++ b/hack/build/ci-binaries.sh
@@ -29,6 +29,7 @@ make clean
 OS_ARCHES=(
   linux_amd64
   linux_arm64
+  linux_ppc64le
   darwin_amd64
   darwin_arm64
 )


### PR DESCRIPTION
Addition of `ppc64le` arch worked fine when I ran `make ci-binaries`. The resulted file had below details when built on x86 machine:
```
[root@raji-x86-workspace1 ppc64le]# file kubetest2
kubetest2: ELF 64-bit LSB executable, 64-bit PowerPC or cisco 7500, version 1 (SYSV), statically linked, with debug_info, not stripped
[root@raji-x86-workspace1 ppc64le]#
```
This change is needed for `kubekins-e2e-v2` support on ppc64le. As at https://github.com/kubernetes/test-infra/blob/master/images/kubekins-e2e-v2/Dockerfile#L168 kubetest2 is referred.

`kubekins` issue :
https://github.com/kubernetes/test-infra/issues/34345
Slack discussion: https://kubernetes.slack.com/archives/CCK68P2Q2/p1739538851706299?thread_ts=1739359083.466129&cid=CCK68P2Q2