### PR TITLE
Add support for GKE extended release channel.

### DIFF
--- a/kubetest2-gke/deployer/options/cluster.go
+++ b/kubetest2-gke/deployer/options/cluster.go
@@ -41,7 +41,7 @@ type ClusterOptions struct {
 	MachineType             string   `flag:"~machine-type" desc:"For use with gcloud commands to specify the machine type for the cluster."`
 	NumNodes                int      `flag:"~num-nodes" desc:"For use with gcloud commands to specify the number of nodes for each of the cluster's zones."`
 	ImageType               string   `flag:"~image-type" desc:"The image type to use for the cluster."`
-	ReleaseChannel          string   `desc:"Use a GKE release channel, could be one of empty, rapid, regular and stable - https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels"`
+	ReleaseChannel          string   `desc:"Use a GKE release channel, could be one of empty, rapid, regular, stable and extended - https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels"`
 	LegacyClusterVersion    string   `flag:"~version,deprecated" desc:"Use --cluster-version instead"`
 	ClusterVersion          string   `desc:"Use a specific GKE version e.g. 1.16.13.gke-400, 'latest' or ''. If --build is specified it will default to building kubernetes from source."`
 	WorkloadIdentityEnabled bool     `flag:"~enable-workload-identity" desc:"Whether enable workload identity for the cluster or not. See the details in https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity."`

--- a/kubetest2-gke/deployer/version.go
+++ b/kubetest2-gke/deployer/version.go
@@ -27,12 +27,13 @@ import (
 )
 
 var (
-	noneReleaseChannel    = "None"
-	rapidReleaseChannel   = "rapid"
-	regularReleaseChannel = "regular"
-	stableReleaseChannel  = "stable"
+	noneReleaseChannel     = "None"
+	rapidReleaseChannel    = "rapid"
+	regularReleaseChannel  = "regular"
+	stableReleaseChannel   = "stable"
+	extendedReleaseChannel = "extended"
 
-	validReleaseChannels = []string{noneReleaseChannel, rapidReleaseChannel, regularReleaseChannel, stableReleaseChannel}
+	validReleaseChannels = []string{noneReleaseChannel, rapidReleaseChannel, regularReleaseChannel, stableReleaseChannel, extendedReleaseChannel}
 )
 
 func validateVersion(version string) error {

--- a/kubetest2-gke/deployer/version_test.go
+++ b/kubetest2-gke/deployer/version_test.go
@@ -104,6 +104,11 @@ func TestValidateReleaseChannel(t *testing.T) {
 			valid:          true,
 		},
 		{
+			desc:           "extended release channel is valid",
+			releaseChannel: "extended",
+			valid:          true,
+		},
+		{
 			desc:           "latest release channel is invalid",
 			releaseChannel: "latest",
 			valid:          false,


### PR DESCRIPTION
Add support for the GKE 'extended' release channel.

Refer to the list of channel described in:
https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels