### PR TITLE
Provide GKE cluster identifiers to tests.

### DIFF
--- a/kubetest2-gke/deployer/deployer.go
+++ b/kubetest2-gke/deployer/deployer.go
@@ -239,6 +239,14 @@ func locationFlag(regions, zones []string, retryCount int) string {
 	return "--region=" + regions[retryCount]
 }
 
+// location builds a location from the provided zone/region.
+func location(regions, zones []string, retryCount int) string {
+	if len(zones) != 0 {
+		return zones[retryCount]
+	}
+	return regions[retryCount]
+}
+
 // regionFromLocation computes the region from the specified zone/region
 // used by some commands (such as subnets), which do not support zones.
 func regionFromLocation(regions, zones []string, retryCount int) string {

--- a/kubetest2-gke/deployer/deployer_test.go
+++ b/kubetest2-gke/deployer/deployer_test.go
@@ -53,6 +53,41 @@ func TestLocationFlag(t *testing.T) {
 	}
 }
 
+func TestLocation(t *testing.T) {
+	testCases := []struct {
+		regions    []string
+		zones      []string
+		retryCount int
+		expected   string
+	}{
+		{
+			regions:    []string{"us-central1"},
+			zones:      []string{},
+			retryCount: 0,
+			expected:   "us-central1",
+		},
+		{
+			regions:    []string{},
+			zones:      []string{"us-central1-c"},
+			retryCount: 0,
+			expected:   "us-central1-c",
+		},
+		{
+			regions:    []string{"us-central1", "us-east"},
+			zones:      []string{},
+			retryCount: 1,
+			expected:   "us-east",
+		},
+	}
+
+	for _, tc := range testCases {
+		got := location(tc.regions, tc.zones, tc.retryCount)
+		if got != tc.expected {
+			t.Errorf("expected %q but got %q", tc.expected, got)
+		}
+	}
+}
+
 func TestRegionFromLocation(t *testing.T) {
 	testCases := []struct {
 		regions    []string

--- a/kubetest2-gke/deployer/up.go
+++ b/kubetest2-gke/deployer/up.go
@@ -141,14 +141,14 @@ func (d *Deployer) clustersSetenv(location string) error {
 			locations = append(locations, location)
 		}
 	}
-	if err := os.Setenv("CLUSTER_PROJECTS", strings.Join(projects, ",")); err != nil {
-		return fmt.Errorf("error setting CLUSTER_PROJECTS: %v", err)
+	if err := os.Setenv("GKE_CLUSTER_PROJECTS", strings.Join(projects, ",")); err != nil {
+		return fmt.Errorf("error setting GKE_CLUSTER_PROJECTS: %v", err)
 	}
-	if err := os.Setenv("CLUSTER_NAMES", strings.Join(names, ",")); err != nil {
-		return fmt.Errorf("error setting CLUSTER_NAMES: %v", err)
+	if err := os.Setenv("GKE_CLUSTER_NAMES", strings.Join(names, ",")); err != nil {
+		return fmt.Errorf("error setting GKE_CLUSTER_NAMES: %v", err)
 	}
-	if err := os.Setenv("CLUSTER_LOCATIONS", strings.Join(locations, ",")); err != nil {
-		return fmt.Errorf("error setting CLUSTER_LOCATIONS: %v", err)
+	if err := os.Setenv("GKE_CLUSTER_LOCATIONS", strings.Join(locations, ",")); err != nil {
+		return fmt.Errorf("error setting GKE_CLUSTER_LOCATIONS: %v", err)
 	}
 	return nil
 }

--- a/kubetest2-gke/deployer/up.go
+++ b/kubetest2-gke/deployer/up.go
@@ -121,7 +121,36 @@ func (d *Deployer) tryCreateClusters(retryCount int) (shouldRetry bool, err erro
 		}
 	}
 
+	if err == nil {
+		err = d.clustersSetenv(location(d.Regions, d.Zones, retryCount))
+	}
+
 	return
+}
+
+// clustersSetenv sets environment variables identifying the created clusters.
+func (d *Deployer) clustersSetenv(location string) error {
+	projects, names, locations := []string{}, []string{}, []string{}
+	for i := range d.Projects {
+		project := d.Projects[i]
+		clusters := d.projectClustersLayout[project]
+		for j := range clusters {
+			cluster := clusters[j]
+			projects = append(projects, project)
+			names = append(names, cluster.name)
+			locations = append(locations, location)
+		}
+	}
+	if err := os.Setenv("CLUSTER_PROJECTS", strings.Join(projects, ",")); err != nil {
+		return fmt.Errorf("error setting CLUSTER_PROJECTS: %v", err)
+	}
+	if err := os.Setenv("CLUSTER_NAMES", strings.Join(names, ",")); err != nil {
+		return fmt.Errorf("error setting CLUSTER_NAMES: %v", err)
+	}
+	if err := os.Setenv("CLUSTER_LOCATIONS", strings.Join(locations, ",")); err != nil {
+		return fmt.Errorf("error setting CLUSTER_LOCATIONS: %v", err)
+	}
+	return nil
 }
 
 // isRetryableError checks if the error happens during cluster creation can be potentially solved by retrying or not.


### PR DESCRIPTION
Provide identifiers of the created cluster(s) to tests.

Following a [sig-testing slack discussion](https://kubernetes.slack.com/archives/C09QZ4DQB/p1755627372200799), to avoid tight-coupling between deployers and test code, this feature is limited to the GKE deployer.

GKE identifies clusters via (name,project,location) triplets. Those are provided via `CLUSTER_NAMES`, `CLUSTER_PROJECTS`, and `CLUSTER_LOCATIONS` environment variables (containing comma-separated lists of identical length).