### PR TITLE
Add back job-version to metadata/finished json for kubetest2 jobs

### DIFF
--- a/pkg/testers/clusterloader2/cl2.go
+++ b/pkg/testers/clusterloader2/cl2.go
@@ -141,7 +141,7 @@ func (t *Tester) Execute() error {
 		fs.PrintDefaults()
 		return nil
 	}
-	if err := testers.WriteVersionToMetadata(GitTag); err != nil {
+	if err := testers.WriteVersionToMetadata(GitTag, ""); err != nil {
 		return err
 	}
 	return t.Test()

--- a/pkg/testers/exec/exec.go
+++ b/pkg/testers/exec/exec.go
@@ -65,7 +65,7 @@ func (t *Tester) Execute() error {
 	}
 
 	t.argv = os.Args[1:]
-	if err := testers.WriteVersionToMetadata(GitTag); err != nil {
+	if err := testers.WriteVersionToMetadata(GitTag, ""); err != nil {
 		return err
 	}
 	return t.Test()

--- a/pkg/testers/ginkgo/ginkgo.go
+++ b/pkg/testers/ginkgo/ginkgo.go
@@ -63,7 +63,7 @@ type Tester struct {
 
 // Test runs the test
 func (t *Tester) Test() error {
-	if err := testers.WriteVersionToMetadata(GitTag); err != nil {
+	if err := testers.WriteVersionToMetadata(GitTag, t.TestPackageVersion); err != nil {
 		return err
 	}
 

--- a/pkg/testers/metadata.go
+++ b/pkg/testers/metadata.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/kubetest2/pkg/metadata"
 )
 
-func WriteVersionToMetadata(version string) error {
+func WriteVersionToMetadata(version string, k8sVersion string) error {
 	var meta *metadata.CustomJSON
 	// check existing metadata and initialize it if it exists
 	metadataPath := filepath.Join(artifacts.BaseDir(), "metadata.json")
@@ -53,6 +53,12 @@ func WriteVersionToMetadata(version string) error {
 
 	if err := meta.Add("tester-version", version); err != nil {
 		return err
+	}
+
+	if k8sVersion != "" {
+		if err := meta.Add("job-version", k8sVersion); err != nil {
+			return err
+		}
 	}
 
 	metadataJSON, err := os.Create(metadataPath)

--- a/pkg/testers/node/node.go
+++ b/pkg/testers/node/node.go
@@ -179,7 +179,7 @@ func (t *Tester) Execute() error {
 			}
 		}
 	}()
-	if err := testers.WriteVersionToMetadata(GitTag); err != nil {
+	if err := testers.WriteVersionToMetadata(GitTag, ""); err != nil {
 		return err
 	}
 	return t.Test()


### PR DESCRIPTION
https://testgrid.k8s.io/sig-arch-conformance#apisnoop-conformance-gate is failing as we switched https://testgrid.k8s.io/conformance-all#Conformance%20-%20GCE%20-%20master from kubetest to kubetest2. the main reason being that the finished.json is missing `"job-version"` Can we please add it back for at least some scenarios?