### PR TITLE
write metadata json after pretestSetup

### DIFF
--- a/pkg/testers/ginkgo/ginkgo.go
+++ b/pkg/testers/ginkgo/ginkgo.go
@@ -63,11 +63,11 @@ type Tester struct {
 
 // Test runs the test
 func (t *Tester) Test() error {
-	if err := testers.WriteVersionToMetadata(GitTag, t.TestPackageVersion); err != nil {
+	if err := t.pretestSetup(); err != nil {
 		return err
 	}
 
-	if err := t.pretestSetup(); err != nil {
+	if err := testers.WriteVersionToMetadata(GitTag, t.TestPackageVersion); err != nil {
 		return err
 	}
 

--- a/pkg/testers/ginkgo/package.go
+++ b/pkg/testers/ginkgo/package.go
@@ -48,7 +48,7 @@ func (t *Tester) AcquireTestPackage() error {
 		}
 		t.TestPackageVersion = resp.String()
 
-		klog.V(1).Infof("Test package version was not specified. Defaulting to version from %s: %s", t.TestPackageMarker, t.TestPackageVersion)
+		klog.V(0).Infof("Test package version was not specified. Defaulting to version from %s: %s", t.TestPackageMarker, t.TestPackageVersion)
 	}
 
 	releaseTar := fmt.Sprintf("kubernetes-test-%s-%s.tar.gz", runtime.GOOS, runtime.GOARCH)

--- a/pkg/testers/metadata.go
+++ b/pkg/testers/metadata.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/kubetest2/pkg/metadata"
 )
 
-func WriteVersionToMetadata(version string, k8sVersion string) error {
+func WriteVersionToMetadata(version string, jobVersion string) error {
 	var meta *metadata.CustomJSON
 	// check existing metadata and initialize it if it exists
 	metadataPath := filepath.Join(artifacts.BaseDir(), "metadata.json")
@@ -55,10 +55,8 @@ func WriteVersionToMetadata(version string, k8sVersion string) error {
 		return err
 	}
 
-	if k8sVersion != "" {
-		if err := meta.Add("job-version", k8sVersion); err != nil {
-			return err
-		}
+	if err := meta.Add("job-version", jobVersion); err != nil {
+		return err
 	}
 
 	metadataJSON, err := os.Create(metadataPath)


### PR DESCRIPTION
pretestSetup (which then calls AcquireTestPackage) actually loads the info we need to print in metadata.json. So let's switch the order of operations here.

let's call it jobVersion (though technically it is the version of the testing tar files. (example - https://dl.k8s.io/ci/v1.35.0-alpha.0.436+ddb015f023b48d/kubernetes-test-linux-amd64.tar.gz)

/assign @ameukam @upodroid 