### PR TITLE
node tester: add support for pre-built binaries

### DIFF
--- a/pkg/testers/node/node.go
+++ b/pkg/testers/node/node.go
@@ -50,6 +50,7 @@ const (
 
 type Tester struct {
 	RepoRoot                       string        `desc:"Absolute path to the kubernetes or provider-aws-test-infra repository root. Only needed when not using some kind of pre-built binaries."`
+	BuildBinaries                  bool          `desc:"Build required binaries in the repo root (required parameter), then call them directly. This is also how UseBuiltBinaries/UseBinariesFromPath/UseBinariesFromPackage work. The traditional and default mode of operation is to call 'make test-e2e-node'."`
 	UseBuiltBinaries               bool          `desc:"Look for binaries in _rundir/$KUBETEST2_RUN_DIR."`
 	UseBinariesFromPath            bool          `desc:"Look for binaries in the $PATH."`
 	UseBinariesFromPackage         bool          `desc:"Look for binaries in a kubernetes test package."`
@@ -250,6 +251,9 @@ func (t *Tester) validateFlags() error {
 	if modeCount != 1 {
 		return errors.New("required exactly one of --repo-root, --use-built-binaries, --use-binaries-from-path, --use-binaries-from-package")
 	}
+	if t.BuildBinaries && t.RepoRoot == "" {
+		return errors.New("--repo-root is required when using --build-binaries")
+	}
 	if t.GCPZone == "" && t.Provider == "gce" {
 		return fmt.Errorf("required --gcp-zone")
 	}
@@ -321,7 +325,7 @@ func (t *Tester) maybeSetupSSHKeys() {
 }
 
 func (t *Tester) constructArgs() []string {
-	if t.RepoRoot == "" {
+	if t.RepoRoot == "" || t.BuildBinaries {
 		// When using pre-built binaries, all parameters get passed through to e2e_node.test
 		// with the exact same parameter names. We could have skipped parsing them earlier
 		// except that we had to parse first to determine in which mode we are operating.
@@ -410,6 +414,9 @@ func (t *Tester) pretestSetup() error {
 			return fmt.Errorf("failed to get packages from published releases: %s", err)
 		}
 	}
+	if t.BuildBinaries {
+		return t.buildBinaries()
+	}
 	return nil
 }
 
@@ -445,10 +452,28 @@ func (t *Tester) validateBinariesFromPath() error {
 	return nil
 }
 
+func (t *Tester) buildBinaries() error {
+	cmd := exec.Command("make", "WHAT=cmd/kubelet ginkgo test/e2e_node/e2e_node.test")
+	cmd.SetDir(t.RepoRoot)
+	exec.InheritOutput(cmd)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("Building test binaries failed: %w", err)
+	}
+	for _, binary := range testBinaries {
+		path := filepath.Join(t.RepoRoot, "_output", "bin", string(binary))
+		if _, err := os.Stat(path); err != nil {
+			return fmt.Errorf("failed to validate binary %s: %w", binary, err)
+		}
+		klog.V(2).Infof("found built %s at %s", binary, path)
+		t.paths[binary] = path
+	}
+	return nil
+}
+
 func (t *Tester) Test() error {
 	var args []string
 	command := ""
-	if t.RepoRoot == "" {
+	if t.RepoRoot == "" || t.BuildBinaries {
 		// When using pre-built binaries, `e2e_node.test remote <flags>` itself is the entry point.
 		command = t.paths[e2eNodeTest]
 		args = []string{"remote"}

--- a/pkg/testers/node/node.go
+++ b/pkg/testers/node/node.go
@@ -21,9 +21,11 @@ limitations under the License.
 package node
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
+	stdexec "os/exec"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -32,6 +34,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/boskos/client"
+	"sigs.k8s.io/kubetest2/pkg/artifacts"
 	"sigs.k8s.io/kubetest2/pkg/boskos"
 	"sigs.k8s.io/kubetest2/pkg/exec"
 	"sigs.k8s.io/kubetest2/pkg/fs"
@@ -41,13 +44,19 @@ import (
 var GitTag string
 
 const (
-	target          = "test-e2e-node"
 	ciPrivateKeyEnv = "GCE_SSH_PRIVATE_KEY_FILE"
 	ciPublicKeyEnv  = "GCE_SSH_PUBLIC_KEY_FILE"
 )
 
 type Tester struct {
-	RepoRoot                       string        `desc:"Absolute path to the kubernetes or provider-aws-test-infra repository root."`
+	RepoRoot                       string        `desc:"Absolute path to the kubernetes or provider-aws-test-infra repository root. Only needed when not using some kind of pre-built binaries."`
+	UseBuiltBinaries               bool          `desc:"Look for binaries in _rundir/$KUBETEST2_RUN_DIR."`
+	UseBinariesFromPath            bool          `desc:"Look for binaries in the $PATH."`
+	UseBinariesFromPackage         bool          `desc:"Look for binaries in a kubernetes test package."`
+	TestPackageURL                 string        `desc:"The url to download a kubernetes test package from."`
+	TestPackageVersion             string        `desc:"The ginkgo tester uses a test package made during the kubernetes build. The tester downloads this test package from one of the release tars published to the Release bucket. Defaults to latest. visit https://kubernetes.io/releases/ to find release names. Example: v1.20.0-alpha.0"`
+	TestPackageDir                 string        `desc:"The directory in the bucket which represents the type of release. Default to the release directory."`
+	TestPackageMarker              string        `desc:"The version marker in the directory containing the package version to download when unspecified. Defaults to latest.txt."`
 	GCPProject                     string        `desc:"GCP Project to create VMs in. If unset, the deployer will attempt to get a project from boskos."`
 	GCPZone                        string        `desc:"GCP Zone to create VMs in."`
 	SkipRegex                      string        `desc:"Regular expression of jobs to skip."`
@@ -85,10 +94,42 @@ type Tester struct {
 	// this contains ssh key path
 	privateKey string
 	sshUser    string
+
+	runDir string
+
+	// These paths are set up while checking for each required binary.
+	// The key is the binary base name (e.g. "e2e_node.test").
+	paths map[bin]string
 }
+
+// These are the binaries required for E2E node testing when using pre-built binaries.
+//
+// Local and remote OS+arch must be the same and are determined by the platform
+// the tester was compiled for. If testing of e.g. linux-arm64 is needed while
+// running in a linux-amd64 Prow container, then --repo-root and building for
+// the target architecture from source have to be used.
+//
+// This restriction comes from running the same e2e_node.test binary both
+// locally and remotely. It could be removed by acquiring that binary once for
+// local and remote platform and adding more parameters to `e2e_node.test
+// remote`, but that would be more complicated everywhere.
+type bin string
+
+const (
+	e2eNodeTest = bin("e2e_node.test")
+	ginkgo      = bin("ginkgo")
+	kubelet     = bin("kubelet")
+)
+
+var (
+	testBinaries = []bin{e2eNodeTest, ginkgo, kubelet}
+)
 
 func NewDefaultTester() *Tester {
 	return &Tester{
+		TestPackageURL:                 "https://dl.k8s.io",
+		TestPackageDir:                 "release",
+		TestPackageMarker:              "latest.txt",
 		SkipRegex:                      `\[Flaky\]|\[Slow\]|\[Serial\]`,
 		BoskosLocation:                 "http://boskos.test-pods.svc.cluster.local.",
 		BoskosAcquireTimeoutSeconds:    5 * 60,
@@ -98,6 +139,7 @@ func NewDefaultTester() *Tester {
 		GCPProjectType:                 "gce-project",
 		Provider:                       "gce",
 		DeleteInstances:                true,
+		paths:                          make(map[bin]string),
 	}
 }
 
@@ -124,6 +166,15 @@ func (t *Tester) Execute() error {
 	}
 	if err := t.validateFlags(); err != nil {
 		return fmt.Errorf("failed to validate flags: %v", err)
+	}
+	if err := t.initKubetest2Info(); err != nil {
+		return err
+	}
+	if err := t.pretestSetup(); err != nil {
+		return err
+	}
+	if err := testers.WriteVersionToMetadata(GitTag, t.TestPackageVersion); err != nil {
+		return err
 	}
 
 	// Use the KUBE_SSH_USER environment variable if it is set. This is particularly
@@ -179,19 +230,49 @@ func (t *Tester) Execute() error {
 			}
 		}
 	}()
-	if err := testers.WriteVersionToMetadata(GitTag, ""); err != nil {
-		return err
-	}
 	return t.Test()
 }
 
 func (t *Tester) validateFlags() error {
-	if t.RepoRoot == "" {
-		return fmt.Errorf("required --repo-root")
+	modeCount := 0
+	if t.RepoRoot != "" {
+		modeCount++
+	}
+	if t.UseBuiltBinaries {
+		modeCount++
+	}
+	if t.UseBinariesFromPath {
+		modeCount++
+	}
+	if t.UseBinariesFromPackage {
+		modeCount++
+	}
+	if modeCount != 1 {
+		return errors.New("required exactly one of --repo-root, --use-built-binaries, --use-binaries-from-path, --use-binaries-from-package")
 	}
 	if t.GCPZone == "" && t.Provider == "gce" {
 		return fmt.Errorf("required --gcp-zone")
 	}
+	return nil
+}
+
+// initKubetest2Info sets relevant information from the well defined kubetest2 environment variables.
+func (t *Tester) initKubetest2Info() error {
+	if dir, ok := os.LookupEnv("KUBETEST2_RUN_DIR"); ok {
+		t.runDir = dir
+		return nil
+	}
+	// Binaries can be found in rundir when they are built
+	if t.UseBuiltBinaries {
+		t.runDir = artifacts.RunDir()
+		return nil
+	}
+	// default to current working directory if for some reason the env is not set
+	dir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to set run dir: %v", err)
+	}
+	t.runDir = dir
 	return nil
 }
 
@@ -240,6 +321,47 @@ func (t *Tester) maybeSetupSSHKeys() {
 }
 
 func (t *Tester) constructArgs() []string {
+	if t.RepoRoot == "" {
+		// When using pre-built binaries, all parameters get passed through to e2e_node.test
+		// with the exact same parameter names. We could have skipped parsing them earlier
+		// except that we had to parse first to determine in which mode we are operating.
+		//
+		// Parsing also provides some early checking for unsupported parameters.
+		// The downside is a closer coupling of the node tester to the k/k repo.
+		args := []string{
+			"--skip-regex=" + t.SkipRegex,
+			"--focus-regex=" + t.FocusRegex,
+			"--label-filter=" + t.LabelFilter,
+			"--gcp-project=" + t.GCPProject,
+			"--gcp-zone=" + t.GCPZone,
+			"--test-args=" + t.TestArgs,
+			"--node-env=" + t.NodeEnv,
+			"--delete-instances=" + strconv.FormatBool(t.DeleteInstances),
+			"--parallelism=" + strconv.Itoa(t.Parallelism),
+			"--image-config-file=" + t.ImageConfigFile,
+			"--image-config-dir=" + t.ImageConfigDir,
+			"--image-project=" + t.ImageProject,
+			"--images=" + t.Images,
+			"--instance-metadata=" + t.InstanceMetadata,
+			"--user-data-file=" + t.UserDataFile,
+			"--instance-type=" + t.InstanceType,
+			"--ssh-user=" + t.sshUser,
+			"--ssh-key=" + t.privateKey,
+			"--timeout=" + t.Timeout.String(),
+
+			// Not relevant: t.UseDockerizedBuild, t.TargetBuildArch
+			// Replaced by:
+			"--ginkgo-binary=" + t.paths[ginkgo],
+			"--kubelet-binary=" + t.paths[kubelet],
+			"--e2e-node-binary=" + t.paths[e2eNodeTest],
+		}
+
+		if t.RuntimeConfig != "" {
+			args = append(args, "--runtime-config="+t.RuntimeConfig)
+		}
+		return args
+	}
+
 	defaultArgs := []string{
 		"REMOTE=true",
 	}
@@ -276,12 +398,71 @@ func (t *Tester) constructArgs() []string {
 	return append(defaultArgs, argsFromFlags...)
 }
 
+func (t *Tester) pretestSetup() error {
+	if t.UseBuiltBinaries {
+		return t.validateLocalBinaries()
+	}
+	if t.UseBinariesFromPath {
+		return t.validateBinariesFromPath()
+	}
+	if t.UseBinariesFromPackage {
+		if err := t.acquirePackages(); err != nil {
+			return fmt.Errorf("failed to get packages from published releases: %s", err)
+		}
+	}
+	return nil
+}
+
+func (t *Tester) validateLocalBinaries() error {
+	klog.V(2).Infof("checking existing test binaries ...")
+	for _, binary := range testBinaries {
+		path := filepath.Join(t.runDir, string(binary))
+		if _, err := os.Stat(path); err != nil {
+			logPath := path
+			if abspath, err := filepath.Abs(path); err != nil {
+				klog.Warningf("failed to convert path %q to absolute path: %v", path, err)
+			} else {
+				logPath = abspath
+			}
+			return fmt.Errorf("failed to validate pre-built binary %s (checked at %q): %w", binary, logPath, err)
+		}
+		klog.V(2).Infof("found existing %s at %s", binary, path)
+		t.paths[binary] = path
+	}
+	return nil
+}
+
+func (t *Tester) validateBinariesFromPath() error {
+	klog.V(2).Infof("checking for test binaries on PATH...")
+	for _, binary := range testBinaries {
+		path, err := stdexec.LookPath(string(binary))
+		if err != nil {
+			return fmt.Errorf("failed to validate binary %s from PATH: %w", binary, err)
+		}
+		klog.V(2).Infof("found existing %s at %s", binary, path)
+		t.paths[binary] = path
+	}
+	return nil
+}
+
 func (t *Tester) Test() error {
 	var args []string
-	args = append(args, target)
+	command := ""
+	if t.RepoRoot == "" {
+		// When using pre-built binaries, `e2e_node.test remote <flags>` itself is the entry point.
+		command = t.paths[e2eNodeTest]
+		args = []string{"remote"}
+	} else {
+		// When using the repository, `make test-e2e-node` bootstraps and runs the test.
+		command = "make"
+		args = []string{"test-e2e-node"}
+	}
 	args = append(args, t.constructArgs()...)
-	cmd := exec.Command("make", args...)
-	cmd.SetDir(t.RepoRoot)
+	cmd := exec.Command(command, args...)
+	if t.RepoRoot != "" {
+		cmd.SetDir(t.RepoRoot)
+	}
+	klog.Infof("Running command %q with arguments %q", command, args)
 	exec.InheritOutput(cmd)
 	return cmd.Run()
 }

--- a/pkg/testers/node/package.go
+++ b/pkg/testers/node/package.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/go-resty/resty/v2"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/kubetest2/pkg/artifacts"
+)
+
+// acquirePackages obtains test binaries and places them in $KUBETEST2_RUN_DIR.
+// The first is "ginkgo", the actual ginkgo executable.
+// The second is "e2e_node.test", which contains kubernetes e2e node test cases.
+// The third is "kubelet".
+func (t *Tester) acquirePackages() error {
+	// first, get the name of the latest release (e.g. v1.20.0-alpha.0)
+	if t.TestPackageVersion == "" {
+		resp, err := resty.New().R().Get(fmt.Sprintf("%s/%s/%s", t.TestPackageURL, t.TestPackageDir, t.TestPackageMarker))
+		if err != nil {
+			return fmt.Errorf("failed to get latest release name: %s", err)
+		}
+		if resp.String() == "" {
+			return fmt.Errorf("getting latest release name had no output")
+		}
+		t.TestPackageVersion = resp.String()
+
+		klog.V(0).Infof("Test package version was not specified. Defaulting to version from %s: %s", t.TestPackageMarker, t.TestPackageVersion)
+	}
+
+	releaseTar := fmt.Sprintf("kubernetes-test-%s-%s.tar.gz", runtime.GOOS, runtime.GOARCH)
+
+	downloadDir, err := os.UserCacheDir()
+	if err != nil {
+		return fmt.Errorf("failed to get user cache directory: %v", err)
+	}
+
+	downloadPath := filepath.Join(downloadDir, releaseTar)
+
+	if err := t.ensureReleaseTar(downloadPath, releaseTar); err != nil {
+		return err
+	}
+	if err := t.extractBinaries(downloadPath, ginkgo, e2eNodeTest); err != nil {
+		return err
+	}
+
+	// Now the same for kubelet in the node package.
+	releaseTar = fmt.Sprintf("kubernetes-node-%s-%s.tar.gz", runtime.GOOS, runtime.GOARCH)
+	downloadPath = filepath.Join(downloadDir, releaseTar)
+	if err := t.ensureReleaseTar(downloadPath, releaseTar); err != nil {
+		return err
+	}
+	if err := t.extractBinaries(downloadPath, kubelet); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *Tester) extractBinaries(downloadPath string, binaries ...bin) error {
+	// ensure the artifacts dir
+	if err := os.MkdirAll(artifacts.BaseDir(), os.ModePerm); err != nil {
+		return err
+	}
+	// ensure the rundir
+	if err := os.MkdirAll(artifacts.RunDir(), os.ModePerm); err != nil {
+		return err
+	}
+
+	// Extract files from the test package
+	f, err := os.Open(downloadPath)
+	if err != nil {
+		return fmt.Errorf("failed to open downloaded tar at %s: %s", downloadPath, err)
+	}
+	defer f.Close()
+	gzf, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("failed to create gzip reader: %s", err)
+	}
+	defer gzf.Close()
+
+	tarReader := tar.NewReader(gzf)
+
+	// Map of paths in archive to destination paths
+	for _, binary := range binaries {
+		t.paths[binary] = filepath.Join(artifacts.RunDir(), string(binary))
+	}
+	// Map paths in the release packages to the binaries that we want to extract.
+	extract := map[string]bin{
+		"kubernetes/test/bin/e2e_node.test": e2eNodeTest,
+		"kubernetes/test/bin/ginkgo":        ginkgo,
+		"kubernetes/node/bin/kubelet":       kubelet,
+	}
+	extracted := map[bin]bool{}
+
+	for {
+		if len(extracted) == len(binaries) {
+			break
+		}
+
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("error during tar read: %s", err)
+		}
+
+		if bin := extract[header.Name]; bin != "" {
+			dest := t.paths[bin]
+			outFile, err := os.Create(dest)
+			if err != nil {
+				return fmt.Errorf("error creating file at %s: %s", dest, err)
+			}
+			defer outFile.Close()
+
+			if err := outFile.Chmod(0700); err != nil {
+				return fmt.Errorf("failed to make %s executable: %s", dest, err)
+			}
+
+			if _, err := io.Copy(outFile, tarReader); err != nil {
+				return fmt.Errorf("error reading data from tar with header name %s: %s", header.Name, err)
+			}
+
+			extracted[bin] = true
+		}
+	}
+	for _, binary := range binaries {
+		if !extracted[binary] {
+			return fmt.Errorf("failed to find %s in %s", binary, downloadPath)
+		}
+	}
+	return nil
+}
+
+// ensureReleaseTar checks if the kubernetes test tarball already exists
+// and verifies the hashes
+// else downloads it from GCS
+func (t *Tester) ensureReleaseTar(downloadPath, releaseTar string) error {
+
+	releaseTarPathInURL := fmt.Sprintf(
+		"%s/%s/%s/%s",
+		t.TestPackageURL,
+		t.TestPackageDir,
+		t.TestPackageVersion,
+		releaseTar,
+	)
+
+	if _, err := os.Stat(downloadPath); err == nil {
+		klog.V(0).Infof("Found existing tar at %v", downloadPath)
+		err := t.compareSHA(downloadPath, releaseTarPathInURL)
+		if err == nil {
+			klog.V(0).Infof("Validated hash for existing tar at %v", downloadPath)
+			return nil
+		}
+		klog.Warning(err)
+	}
+
+	klog.V(0).Infof("Downloading tar ball from: %s", releaseTarPathInURL)
+	_, err := resty.New().R().SetOutput(downloadPath).Get(releaseTarPathInURL)
+	if err != nil {
+		return fmt.Errorf("failed to download release tar %s for release %s: %s", releaseTar, t.TestPackageVersion, err)
+	}
+	return nil
+}
+
+func (t *Tester) compareSHA(downloadPath string, gcsFilePath string) error {
+	resp, err := resty.New().R().Get(fmt.Sprintf("%s.sha256", gcsFilePath))
+	if err != nil {
+		return fmt.Errorf("failed to get sha256 for file %s for release %s: %s", gcsFilePath, t.TestPackageVersion, err)
+	}
+	expectedSHA := resp.String()
+	actualSHA, err := sha256sum(downloadPath)
+	if err != nil {
+		return fmt.Errorf("failed to compute sha256 for %q: %v", downloadPath, err)
+	}
+	if actualSHA != expectedSHA {
+		return fmt.Errorf("sha256 does not match")
+	}
+	return nil
+}
+
+func sha256sum(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}


### PR DESCRIPTION
When using pre-built binaries (regardless where they come from) we cannot go through `make test-e2e-node` because that doesn't know about pre-built binaries and the make rules are probably not available anyway. Instead, `e2e_node.test remote` serves as entry point with the same command line flags as in the node tester itself.

The node tester is responsible for locating binaries, using the same methods as the ginkgo tester. The code for that was copied instead of refactoring into a common helper to avoid breaking the ginkgo tester.

The node tester also talks to Boskos to obtain a GCP project if needed, as before.

This depends on https://github.com/kubernetes/kubernetes/pull/139129.

Discussed in Slack: https://kubernetes.slack.com/archives/C09QZ4DQB/p1779101528827609