### PR TITLE
gce: document that cloud-provider-gcp no longer works

### DIFF
--- a/kubetest2-gce/README.md
+++ b/kubetest2-gce/README.md
@@ -6,17 +6,18 @@ The [original design proposal](https://docs.google.com/document/d/157nSQNyy9cOjw
 
 ## Usage
 
-Currently, the GCE deployer must be running on a system with a version of k/k or the cloud-provider-gcp repository cloned (necessary because of the reliance on scripts, see Implementation). A simple run without running tests looks as follows:
+Currently, the GCE deployer must be running on a system with a version of k/k repository cloned (necessary because of the reliance on scripts, see Implementation). A simple run without running tests looks as follows:
 
 ```
 kubetest2 gce --gcp-project $TARGETPROJECT --repo-root $CLONEDREPOPATH --build --up --down
 ```
 
-If targeting k/k instead of cloud-provider-gcp, you must add `--legacy-mode` so the deployer knows how to build the code.
+When using k/k (the only supported option right now), you must add `--legacy-mode` so the deployer knows how to build the code.
+The code which was added for cloud-provider-gcp still exists, but is no longer tested.
 
 The deployer supports Boskos, so `--gcp-project` can be skipped if there is an available Boskos instance running.
 
 See the usage (`--help`) for more options.
 
 ## Implementation
-The deployer is essentially a Golang wrapper for `kube-up.sh` and `kube-down.sh` located [here](https://github.com/kubernetes/kubernetes/tree/master/cluster) in k/k and [here](https://github.com/kubernetes/cloud-provider-gcp/tree/master/cluster) in cloud-provider-gcp. It replaces bash scripts located [here](https://github.com/kubernetes/kubernetes/tree/master/hack/e2e-internal). See the design proposal for a deeper explanation.
+The deployer is essentially a Golang wrapper for `kube-up.sh` and `kube-down.sh` located [here](https://github.com/kubernetes/kubernetes/tree/master/cluster) in k/k and [previously here](https://github.com/kubernetes/cloud-provider-gcp/tree/release-1.36/cluster) in cloud-provider-gcp. It replaces bash scripts located [here](https://github.com/kubernetes/kubernetes/tree/master/hack/e2e-internal). See the design proposal for a deeper explanation.


### PR DESCRIPTION
https://github.com/kubernetes/cloud-provider-gcp/pull/1116 removed the "cluster" directory, causing pull-kubetest2-gce-build-up-down to fail.

For now let's document this. We could also try to change the code, but that comes with the risk of breaking the working "legacy" mode.

Prow job removal is in https://github.com/kubernetes/test-infra/pull/37096.

/cc @BenTheElder @upodroid 