### PR TITLE
app: add --metadata flag to record extra key=value pairs in metadata.json

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -74,7 +74,7 @@ func RealMain(opts types.Options, d types.Deployer, tester types.Tester) (result
 		return err
 	}
 
-	if err := writeVersionToMetadataJSON(d); err != nil {
+	if err := writeVersionToMetadataJSON(d, opts.Metadata()); err != nil {
 		return err
 	}
 
@@ -236,7 +236,7 @@ func RealMain(opts types.Options, d types.Deployer, tester types.Tester) (result
 	return postTestErr
 }
 
-func writeVersionToMetadataJSON(d types.Deployer) error {
+func writeVersionToMetadataJSON(d types.Deployer, extra map[string]string) error {
 	// setup the json metadata writer
 	metadataJSON, err := os.Create(
 		filepath.Join(artifacts.BaseDir(), "metadata.json"),
@@ -255,6 +255,12 @@ func writeVersionToMetadataJSON(d types.Deployer) error {
 
 	if dWithVersion, ok := d.(types.DeployerWithVersion); ok {
 		if err := meta.Add("deployer-version", dWithVersion.Version()); err != nil {
+			return err
+		}
+	}
+
+	for k, v := range extra {
+		if err := meta.Add(k, v); err != nil {
 			return err
 		}
 	}

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type fakeDeployer struct{}
+
+func (fakeDeployer) Up() error              { return nil }
+func (fakeDeployer) Down() error            { return nil }
+func (fakeDeployer) IsUp() (bool, error)    { return false, nil }
+func (fakeDeployer) DumpClusterLogs() error { return nil }
+func (fakeDeployer) Build() error           { return nil }
+
+func TestWriteVersionToMetadataJSONExtra(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ARTIFACTS", dir)
+
+	if err := writeVersionToMetadataJSON(fakeDeployer{}, map[string]string{"variant": "restart"}); err != nil {
+		t.Fatalf("writeVersionToMetadataJSON: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "metadata.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal %s: %v", data, err)
+	}
+	if got["variant"] != "restart" {
+		t.Errorf("variant not recorded, got %v", got)
+	}
+	if _, ok := got["kubetest-version"]; !ok {
+		t.Errorf("kubetest-version not written, got %v", got)
+	}
+}

--- a/pkg/app/cmd.go
+++ b/pkg/app/cmd.go
@@ -197,6 +197,7 @@ type options struct {
 	rundirInArtifacts   bool
 	preTestCmd          []string
 	postTestCmd         []string
+	metadata            map[string]string
 }
 
 // bindFlags registers all first class kubetest2 flags
@@ -219,6 +220,7 @@ func (o *options) bindFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&o.rundirInArtifacts, "rundir-in-artifacts", false, `if true, the test binaries and run specific metadata will be in the ARTIFACTS`)
 	flags.StringSliceVar(&o.postTestCmd, "post-test-cmd", nil, "command and args to run after the tester, inherits the deployer environment (e.g. --post-test-cmd=post-test.sh,--flag,value)")
 	flags.StringSliceVar(&o.preTestCmd, "pre-test-cmd", nil, "command and args to run after the deployer (up) but before the tester, inherits the deployer environment (e.g. --pre-test-cmd=kubectl,apply,-f,foo.yaml)")
+	flags.StringToStringVar(&o.metadata, "metadata", nil, "extra key=value pairs to record in metadata.json, repeatable (e.g. --metadata=variant=restart)")
 }
 
 // assert that options implements deployer options
@@ -281,6 +283,10 @@ func (o *options) PostTestCmd() []string {
 
 func (o *options) PreTestCmd() []string {
 	return o.preTestCmd
+}
+
+func (o *options) Metadata() map[string]string {
+	return o.metadata
 }
 
 // metadata used for CLI usage string

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -66,6 +66,8 @@ type Options interface {
 	PostTestCmd() []string
 	// PreTestCmd returns a command (and args) to run after the deployer but before the tester
 	PreTestCmd() []string
+	// Metadata returns extra key=value pairs to record in metadata.json
+	Metadata() map[string]string
 }
 
 // Deployer defines the interface between kubetest and a deployer


### PR DESCRIPTION
Adds a repeatable --metadata key=value flag whose pairs are written into ${ARTIFACTS}/metadata.json alongside the version keys. This lets jobs record per-run metadata (e.g. an experiment variant for a TestGrid column header) without hand-writing the file, which kubetest2 would otherwise overwrite at startup.